### PR TITLE
Fix: Add instance requests to JSON session logs

### DIFF
--- a/lib/claude_swarm/claude_code_executor.rb
+++ b/lib/claude_swarm/claude_code_executor.rb
@@ -113,6 +113,16 @@ module ClaudeSwarm
 
     def log_request(prompt)
       @logger.info("#{@calling_instance} -> #{@instance_name}: \n---\n#{prompt}\n---")
+      
+      # Also log to JSON for complete audit trail
+      request_event = {
+        type: "instance_request",
+        message: {
+          role: "user",
+          content: prompt
+        }
+      }
+      append_to_session_json(request_event)
     end
 
     def log_response(response)


### PR DESCRIPTION
## Summary
Instance requests from main to expert agents were only logged to text files, creating incomplete JSON audit trails. This PR fixes the asymmetric logging by ensuring all events are logged to both text and JSON formats.

## Changes
- Updated `log_request` method in `claude_code_executor.rb` to call `append_to_session_json`
- Used generic `"instance_request"` event type that works regardless of main instance naming
- Added comprehensive tests for JSON logging and append behavior
- Maintains backward compatibility - only adds new JSON events

## Test Results
- All existing tests pass
- New tests verify JSON structure and append behavior
- Validates ISO-8601 timestamp format

## Impact
- Complete audit trail now available in JSON logs
- Better debugging and analysis capabilities  
- No breaking changes to existing functionality

🤖 Generated with Claude Code