### PR TITLE
haiku model seems to be deprecated, but usable if the exact version specified

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,7 @@ A collection of Claude instances (agents) working together. One instance is desi
 An individual Claude Code agent with:
 - **description** (required): Role and responsibilities
 - **directory**: Working directory context
-- **model**: Claude model (opus/sonnet/haiku)
+- **model**: Claude model (opus/sonnet/claude-3-5-haiku-20241022)
 - **connections**: Other instances it can delegate to
 - **allowed_tools**: Tools this instance can use
 - **disallowed_tools**: Explicitly denied tools (override allowed)
@@ -79,7 +79,7 @@ swarm:
     instance_name:
       description: "Agent role description"  # REQUIRED
       directory: ~/path/to/dir              # Working directory
-      model: opus                           # opus/sonnet/haiku
+      model: opus                           # opus/sonnet/claude-3-5-haiku-20241022
       connections: [other1, other2]         # Connected instances
       prompt: "Custom system prompt"        # Additional instructions
       vibe: false                          # Skip permissions (default: false)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -66,7 +66,7 @@ class ConfigurationTest < Minitest::Test
           backend:
             description: "Backend developer instance"
             directory: ./backend
-            model: haiku
+            model: claude-3-5-haiku-20241022
             tools: [Bash, Grep]
             prompt: "You handle backend tasks"
           frontend:

--- a/test/fixtures/swarm_configs.rb
+++ b/test/fixtures/swarm_configs.rb
@@ -111,7 +111,7 @@ module Fixtures
             frontend:
               description: "Frontend developer building user interfaces"
               directory: ./frontend
-              model: haiku
+              model: claude-3-5-haiku-20241022
               tools: [Edit, Bash, Read]
               prompt: "You build user interfaces"
             database:

--- a/test/mcp_generator_test.rb
+++ b/test/mcp_generator_test.rb
@@ -64,7 +64,7 @@ class McpGeneratorTest < Minitest::Test
           backend:
             description: "Backend instance"
             directory: ./backend
-            model: haiku
+            model: claude-3-5-haiku-20241022
             tools: [Bash, Grep]
             prompt: "Backend developer"
           frontend:
@@ -106,7 +106,7 @@ class McpGeneratorTest < Minitest::Test
       assert dir_index, "Should have --directory flag"
       assert args[dir_index + 1].end_with?("backend"), "Directory should end with 'backend'"
       assert_includes args, "--model"
-      assert_includes args, "haiku"
+      assert_includes args, "claude-3-5-haiku-20241022"
       assert_includes args, "--prompt"
       assert_includes args, "Backend developer"
       assert_includes args, "--allowed-tools"


### PR DESCRIPTION
Using claude-swarm, I found the haiku model name was no longer a valid model in claude code.
This specific one (in pull request), was still usable, though that's likely going to phase out too, given that I couldn't set the model names to any of the legacy ones.

As of Jun 18, 2025, these other models are also usable:

Claude 3.7 Models:
* claude-3-7-sonnet-20250219

Claude 3.5 Models:
* claude-3-5-haiku-20241022
* claude-3-5-sonnet-20241022