### PR TITLE
Add install Claude to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,13 @@ Claude Swarm orchestrates multiple Claude Code instances as a collaborative AI d
 
 ## Installation
 
-Install the gem by executing:
+Install [Claude CLI](https://docs.anthropic.com/en/docs/claude-code/overview) if you haven't already:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Install this gem by executing:
 
 ```bash
 gem install claude_swarm


### PR DESCRIPTION
README first has installation, then prerequisites below. I didn't have a working version of Claude on my laptop and errors weren't super helpful. I can swap "Prerequisites" with "Installation" too if that's better.

Closes #28 