### PR TITLE
Fix: use command to test existence of Claude CLI.

### DIFF
--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -203,8 +203,8 @@ module ClaudeSwarm
     method_option :model, aliases: "-m", type: :string, default: "sonnet",
                           desc: "Claude model to use for generation"
     def generate
-      # Check if claude command exists
-      unless system("which claude > /dev/null 2>&1")
+      # Check if claude command exists (works with aliases)
+      unless system("command -v claude > /dev/null 2>&1")
         error "Claude CLI is not installed or not in PATH"
         say "To install Claude CLI, visit: https://docs.anthropic.com/en/docs/claude-code"
         exit 1

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -371,8 +371,10 @@ class CLITest < Minitest::Test
   end
 
   def test_generate_without_claude_installed
-    # Mock system call to simulate Claude not being installed
-    @cli.stub :system, false do
+    # Mock system call to simulate Claude not being installed (command -v fails)
+    @cli.stub :system, lambda { |cmd|
+      !cmd.include?("command -v claude")
+    } do
       out, = capture_cli_output do
         assert_raises(SystemExit) { @cli.generate }
       end
@@ -383,8 +385,10 @@ class CLITest < Minitest::Test
   end
 
   def test_generate_with_claude_installed
-    # Mock system call to simulate Claude being installed
-    @cli.stub :system, true do
+    # Mock system call to simulate Claude being installed (command -v succeeds)
+    @cli.stub :system, lambda { |cmd|
+      cmd.include?("command -v claude") || false
+    } do
       # Read the actual template file before stubbing
       actual_template_path = File.expand_path("../lib/claude_swarm/templates/generation_prompt.md.erb", __dir__)
       template_content = File.read(actual_template_path)


### PR DESCRIPTION
Using `which` does not return anything for aliases, which is how Claude is configured when installed in local dir.

```
alias claude='/Users/dblock/.claude/local/claude'
```

Closes #30 