### PR TITLE
Fix: display copy-pastable debug output.

### DIFF
--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # External dependencies
+require "time"
 require "thor"
 require "yaml"
 require "json"

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -171,7 +171,7 @@ module ClaudeSwarm
 
       command = build_main_command(main_instance)
       if @debug && !@prompt
-        puts "Running: #{command}"
+        puts "🏃 Running: #{format_command_for_display(command)}"
         puts
       end
 
@@ -357,6 +357,16 @@ module ClaudeSwarm
       rescue StandardError
         # Silently handle errors (file might be deleted, process might end, etc.)
       end
+    end
+
+    def format_command_for_display(command)
+      command.map do |part|
+        if part.match?(/\s|'|"/)
+          "'#{part.gsub("'", "'\\\\''")}'"
+        else
+          part
+        end
+      end.join(" ")
     end
 
     def build_main_command(instance)

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -262,7 +262,7 @@ class OrchestratorTest < Minitest::Test
       output = capture_io { orchestrator.start }[0]
     end
 
-    assert_match(/Running: \["claude".*--model.*\]/, output)
+    assert_match(/🏃 Running: claude --model.*/, output)
   end
 
   def test_empty_connections_and_tools


### PR DESCRIPTION
Before:

```
Running: ["claude", "--model", "opus", "--allowedTools", "Bash,mcp__ruby_upgrader", "--append-system-prompt", "Find the Ruby projects in this directory.\nDo not recurse further than 3 levels deep.\nFor each project, identify the Ruby version used.\nPrint the project name next to the ruby version only.\nFor the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.\n", "--debug", "--mcp-config", "/Users/dblock/.claude-swarm/sessions/Users+dblock+source+slack+swarm/20250622_084736/lead_developer.mcp.json", "Find the Ruby projects in this directory.\nDo not recurse further than 3 levels deep.\nFor each project, identify the Ruby version used.\nPrint the project name next to the ruby version only.\nFor the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.\n\n\nNow just say 'I am ready to start'"]
```

After:

```
🏃 Running: claude --model opus --allowedTools Bash,mcp__ruby_upgrader --append-system-prompt 'Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.
' --debug --mcp-config /Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_084813/lead_developer.mcp.json 'Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.


Now just say '\''I am ready to start'\'''
```

Closes #29 