### PR TITLE
Fix: do not hide command line errors.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Naming/AccessorMethodName:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/BlockNesting:
+  Enabled: false  
+
 Metrics/ClassLength:
   Enabled: false
 

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -6,6 +6,7 @@ require "erb"
 
 module ClaudeSwarm
   class CLI < Thor
+    include SystemUtils
     def self.exit_on_failure?
       true
     end
@@ -203,8 +204,10 @@ module ClaudeSwarm
     method_option :model, aliases: "-m", type: :string, default: "sonnet",
                           desc: "Claude model to use for generation"
     def generate
-      # Check if claude command exists (works with aliases)
-      unless system("command -v claude > /dev/null 2>&1")
+      # Check if claude command exists
+      begin
+        system!("command -v claude > /dev/null 2>&1")
+      rescue Error
         error "Claude CLI is not installed or not in PATH"
         say "To install Claude CLI, visit: https://docs.anthropic.com/en/docs/claude-code"
         exit 1
@@ -515,8 +518,8 @@ module ClaudeSwarm
                   repo_path = repo_git_path.split("/.git/worktrees/").first
 
                   # Try to remove worktree via git
-                  system("git", "-C", repo_path, "worktree", "remove", worktree_path, "--force",
-                         out: File::NULL, err: File::NULL)
+                  system!("git", "-C", repo_path, "worktree", "remove", worktree_path, "--force",
+                          out: File::NULL, err: File::NULL)
                 end
               end
 

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -7,6 +7,7 @@ require "fileutils"
 
 module ClaudeSwarm
   class Orchestrator
+    include SystemUtils
     RUN_DIR = File.expand_path("~/.claude-swarm/run")
 
     def initialize(configuration, mcp_generator, vibe: false, prompt: nil, stream_logs: false, debug: false,
@@ -181,7 +182,7 @@ module ClaudeSwarm
 
       # Execute the main instance - this will cascade to other instances via MCP
       Dir.chdir(main_instance[:directory]) do
-        system(*command)
+        system!(*command)
       end
 
       # Clean up log streaming thread

--- a/lib/claude_swarm/system_utils.rb
+++ b/lib/claude_swarm/system_utils.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "English"
+
+module ClaudeSwarm
+  module SystemUtils
+    def system!(*args)
+      success = system(*args)
+      unless success
+        exit_status = $CHILD_STATUS&.exitstatus || 1
+        command_str = args.size == 1 ? args.first : args.join(" ")
+        warn "❌ Command failed with exit status: #{exit_status}"
+        raise Error, "Command failed with exit status #{exit_status}: #{command_str}"
+      end
+      success
+    end
+  end
+end

--- a/lib/claude_swarm/worktree_manager.rb
+++ b/lib/claude_swarm/worktree_manager.rb
@@ -9,6 +9,7 @@ require "digest"
 
 module ClaudeSwarm
   class WorktreeManager
+    include SystemUtils
     attr_reader :shared_worktree_name, :created_worktrees
 
     def initialize(cli_worktree_option = nil, session_id: nil)
@@ -350,7 +351,11 @@ module ClaudeSwarm
         else
           # The worktree is registered but the directory doesn't exist, prune and retry
           puts "Pruning stale worktree references" unless ENV["CLAUDE_SWARM_PROMPT"]
-          system("git", "-C", repo_root, "worktree", "prune")
+          begin
+            system!("git", "-C", repo_root, "worktree", "prune")
+          rescue Error
+            # Ignore errors when pruning
+          end
           output, status = Open3.capture2e("git", "-C", repo_root, "worktree", "add", worktree_path, branch_name)
         end
       end


### PR DESCRIPTION
Before:

```
$ claude-swarm --debug ~/source/slack/swarm/claude-swarm.yml
Starting Claude Swarm from /Users/dblock/source/slack/swarm/claude-swarm.yml...
🐝 Starting Claude Swarm: Ruby Upgrade Swarm

📝 Session files will be saved to: /Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_090410/

✓ Generated MCP configurations in session directory

⚙️  Executing before commands...

Debug: Executing command 1/1: echo 'Getting started ...'
Command 1 output:
Getting started ...
Exit status: 0
✓ Before commands completed successfully

🚀 Launching main instance: lead_developer
   Model: opus
   Directory: /Users/dblock/source/claude-swarm
   Allowed tools: Bash
   Connections: ruby_upgrader

Running: ["claude", "--model", "opus", "--allowedTools", "Bash,mcp__ruby_upgrader", "--append-system-prompt", "Find the Ruby projects in this directory.\nDo not recurse further than 3 levels deep.\nFor each project, identify the Ruby version used.\nPrint the project name next to the ruby version only.\nFor the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.\n", "--debug", "--mcp-config", "/Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_090410/lead_developer.mcp.json", "Find the Ruby projects in this directory.\nDo not recurse further than 3 levels deep.\nFor each project, identify the Ruby version used.\nPrint the project name next to the ruby version only.\nFor the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.\n\n\nNow just say 'I am ready to start'"]

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                                    │
│ Do you trust the files in this folder?                                                                                                                                                                             │
│                                                                                                                                                                                                                    │
│ /Users/dblock/source/claude-swarm                                                                                                                                                                                  │
│                                                                                                                                                                                                                    │
│ Claude Code may read files in this folder. Reading untrusted files may lead Claude Code to behave in unexpected ways.                                                                                              │
│                                                                                                                                                                                                                    │
│ With your permission Claude Code may execute files in this folder. Executing untrusted code is unsafe.                                                                                                             │
│                                                                                                                                                                                                                    │
│ https://docs.anthropic.com/s/claude-code-security                                                                                                                                                                  │
│                                                                                                                                                                                                                    │
│   1. Yes, proceed                                                                                                                                                                                                  │
│ ❯ 2. No, exit✔                                                                                                                                                                                                     │
│                                                                                                                                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
   Enter to confirm · Esc to exit
✓ Cleanup complete
```

After:

```
$ bundle exec ./exe/claude-swarm --debug ~/source/slack/swarm/claude-swarm.yml
Starting Claude Swarm from /Users/dblock/source/slack/swarm/claude-swarm.yml...
🐝 Starting Claude Swarm: Ruby Upgrade Swarm

📝 Session files will be saved to: /Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_090000/

✓ Generated MCP configurations in session directory

⚙️  Executing before commands...

Debug: Executing command 1/1: echo 'Getting started ...'
Command 1 output:
Getting started ...
Exit status: 0
✓ Before commands completed successfully

🚀 Launching main instance: lead_developer
   Model: opus
   Directory: /Users/dblock/source/claude-swarm
   Allowed tools: Bash
   Connections: ruby_upgrader

🏃 Running: claude --model opus --allowedTools Bash,mcp__ruby_upgrader --append-system-prompt 'Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.
' --debug --mcp-config /Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_090000/lead_developer.mcp.json 'Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.


Now just say '\''I am ready to start'\'''

╭────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                                                                                    │
│ Do you trust the files in this folder?                                                                                                                                                                             │
│                                                                                                                                                                                                                    │
│ /Users/dblock/source/claude-swarm                                                                                                                                                                                  │
│                                                                                                                                                                                                                    │
│ Claude Code may read files in this folder. Reading untrusted files may lead Claude Code to behave in unexpected ways.                                                                                              │
│                                                                                                                                                                                                                    │
│ With your permission Claude Code may execute files in this folder. Executing untrusted code is unsafe.                                                                                                             │
│                                                                                                                                                                                                                    │
│ https://docs.anthropic.com/s/claude-code-security                                                                                                                                                                  │
│                                                                                                                                                                                                                    │
│   1. Yes, proceed                                                                                                                                                                                                  │
│ ❯ 2. No, exit✔                                                                                                                                                                                                     │
│                                                                                                                                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
   Enter to confirm · Esc to exit
❌ Command failed with exit status: 1
Command failed with exit status 1: claude --model opus --allowedTools Bash,mcp__ruby_upgrader --append-system-prompt Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.
 --debug --mcp-config /Users/dblock/.claude-swarm/sessions/Users+dblock+source+claude-swarm+dblock-claude-swarm/20250622_090000/lead_developer.mcp.json Find the Ruby projects in this directory.
Do not recurse further than 3 levels deep.
For each project, identify the Ruby version used.
Print the project name next to the ruby version only.
For the first 5 projects with a Ruby version older than 3.5.5 use ruby_upgrader to upgrade the Ruby version.


Now just say 'I am ready to start'
```