### PR TITLE
Add `license` to the gemspec

### DIFF
--- a/claude_swarm.gemspec
+++ b/claude_swarm.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
     agents for frontend, backend, testing, DevOps, or research tasks.
   DESC
   spec.homepage = "https://github.com/parruda/claude-swarm"
+  spec.license = "MIT"
   spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
Currently, `Licenses` in https://rubygems.org/gems/claude_swarm isn't shown. This is because `license` isn't written in the gemspec. This PR adds it to show the `Licenses` in the rubygems.