### PR TITLE
Remove platform suffix in `Gemfile.lock`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,7 +209,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
-  arm64-darwin-23
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
When using a newer version of macOS (`arm64-darwin-24` in my case), running `bundle` causes changes to `Gemfile.lock`. The suffix can be removed to avoid this.

Discussion: https://github.com/rubygems/rubygems/issues/7407