### PR TITLE
Fix RuboCop style violations

### DIFF
--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -7,8 +7,10 @@ require "erb"
 module ClaudeSwarm
   class CLI < Thor
     include SystemUtils
-    def self.exit_on_failure?
-      true
+    class << self
+      def exit_on_failure?
+        true
+      end
     end
 
     desc "start [CONFIG_FILE]", "Start a Claude Swarm from configuration file"

--- a/lib/claude_swarm/openai_responses.rb
+++ b/lib/claude_swarm/openai_responses.rb
@@ -172,18 +172,20 @@ module ClaudeSwarm
           process_responses_api(nil, new_conversation, response_id, depth + 1)
         else
           # Look for text response
-          text_output = output.find { |item| item["content"] }
-          if text_output && text_output["content"].is_a?(Array)
-            text_content = text_output["content"].find { |item| item["text"] }
-            text_content ? text_content["text"] : ""
-          else
-            ""
-          end
+          extract_text_response(output)
         end
       else
         @executor.error("Unexpected output format: #{output.inspect}")
         "Error: Unexpected response format"
       end
+    end
+
+    def extract_text_response(output)
+      text_output = output.find { |item| item["content"] }
+      return "" unless text_output && text_output["content"].is_a?(Array)
+
+      text_content = text_output["content"].find { |item| item["text"] }
+      text_content ? text_content["text"] : ""
     end
 
     def build_conversation_with_outputs(function_calls)

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -143,7 +143,7 @@ module ClaudeSwarm
           puts
         end
 
-        success = execute_before_commands(before_commands)
+        success = execute_before_commands?(before_commands)
         unless success
           puts "❌ Before commands failed. Aborting swarm launch." unless @prompt
           cleanup_processes
@@ -208,7 +208,7 @@ module ClaudeSwarm
 
     private
 
-    def execute_before_commands(commands)
+    def execute_before_commands?(commands)
       log_file = File.join(@session_path, "session.log") if @session_path
 
       commands.each_with_index do |command, index|

--- a/lib/claude_swarm/process_tracker.rb
+++ b/lib/claude_swarm/process_tracker.rb
@@ -62,11 +62,13 @@ module ClaudeSwarm
       FileUtils.rm_rf(@pids_dir)
     end
 
-    def self.cleanup_session(session_path)
-      return unless Dir.exist?(File.join(session_path, PIDS_DIR))
+    class << self
+      def cleanup_session(session_path)
+        return unless Dir.exist?(File.join(session_path, PIDS_DIR))
 
-      tracker = new(session_path)
-      tracker.cleanup_all
+        tracker = new(session_path)
+        tracker.cleanup_all
+      end
     end
 
     private

--- a/test/fixtures/swarm_configs.rb
+++ b/test/fixtures/swarm_configs.rb
@@ -2,151 +2,153 @@
 
 module Fixtures
   module SwarmConfigs
-    def self.minimal
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Minimal Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance for minimal configuration"
-      YAML
-    end
+    class << self
+      def minimal
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Minimal Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance for minimal configuration"
+        YAML
+      end
 
-    def self.with_connections
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Connected Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance connecting to backend and frontend"
-              connections: [backend, frontend]
-            backend:
-              description: "Backend service instance"
-              directory: ./backend
-            frontend:
-              description: "Frontend service instance"
-              directory: ./frontend
-      YAML
-    end
+      def with_connections
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Connected Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance connecting to backend and frontend"
+                connections: [backend, frontend]
+              backend:
+                description: "Backend service instance"
+                directory: ./backend
+              frontend:
+                description: "Frontend service instance"
+                directory: ./frontend
+        YAML
+      end
 
-    def self.with_tools
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Tooled Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Instance with various tool access"
-              tools: [Read, Edit, Bash, Grep]
-      YAML
-    end
+      def with_tools
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Tooled Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Instance with various tool access"
+                tools: [Read, Edit, Bash, Grep]
+        YAML
+      end
 
-    def self.with_tool_patterns
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Pattern Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Instance with pattern-based tool restrictions"
-              tools:
-                - Read
-                - Edit
-                - Bash
-                - Grep
-      YAML
-    end
+      def with_tool_patterns
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Pattern Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Instance with pattern-based tool restrictions"
+                tools:
+                  - Read
+                  - Edit
+                  - Bash
+                  - Grep
+        YAML
+      end
 
-    def self.with_mcps
-      <<~YAML
-        version: 1
-        swarm:
-          name: "MCP Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Instance with multiple MCP server configurations"
-              mcps:
-                - name: "stdio_server"
-                  type: "stdio"
-                  command: "test-server"
-                  args: ["--port", "3000"]
-                - name: "sse_server"
-                  type: "sse"
-                  url: "http://localhost:8080/events"
-      YAML
-    end
+      def with_mcps
+        <<~YAML
+          version: 1
+          swarm:
+            name: "MCP Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Instance with multiple MCP server configurations"
+                mcps:
+                  - name: "stdio_server"
+                    type: "stdio"
+                    command: "test-server"
+                    args: ["--port", "3000"]
+                  - name: "sse_server"
+                    type: "sse"
+                    url: "http://localhost:8080/events"
+        YAML
+      end
 
-    def self.full_featured
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Full Featured Swarm"
-          main: lead
-          instances:
-            lead:
-              description: "Lead developer coordinating the entire team"
-              directory: ./lead
-              model: opus
-              connections: [backend, frontend, tester]
-              tools: [Read, Edit, Bash, Grep]
-              prompt: "You are the lead developer coordinating the team"
-              mcps:
-                - name: "monitor"
-                  type: "stdio"
-                  command: "monitor-server"
-            backend:
-              description: "Backend developer handling API and server logic"
-              directory: ./backend
-              model: sonnet
-              connections: [database]
-              tools: [Bash, Edit, Read]
-              prompt: "You handle API and backend logic"
-            frontend:
-              description: "Frontend developer building user interfaces"
-              directory: ./frontend
-              model: claude-3-5-haiku-20241022
-              tools: [Edit, Bash, Read]
-              prompt: "You build user interfaces"
-            database:
-              description: "Database specialist managing data operations"
-              directory: ./db
-              tools: [Bash]
-            tester:
-              description: "Test engineer ensuring code quality"
-              directory: ./tests
-              model: sonnet
-              tools: [Bash, Read, Edit]
-              mcps:
-                - name: "test_reporter"
-                  type: "sse"
-                  url: "http://localhost:9000/test-results"
-      YAML
-    end
+      def full_featured
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Full Featured Swarm"
+            main: lead
+            instances:
+              lead:
+                description: "Lead developer coordinating the entire team"
+                directory: ./lead
+                model: opus
+                connections: [backend, frontend, tester]
+                tools: [Read, Edit, Bash, Grep]
+                prompt: "You are the lead developer coordinating the team"
+                mcps:
+                  - name: "monitor"
+                    type: "stdio"
+                    command: "monitor-server"
+              backend:
+                description: "Backend developer handling API and server logic"
+                directory: ./backend
+                model: sonnet
+                connections: [database]
+                tools: [Bash, Edit, Read]
+                prompt: "You handle API and backend logic"
+              frontend:
+                description: "Frontend developer building user interfaces"
+                directory: ./frontend
+                model: claude-3-5-haiku-20241022
+                tools: [Edit, Bash, Read]
+                prompt: "You build user interfaces"
+              database:
+                description: "Database specialist managing data operations"
+                directory: ./db
+                tools: [Bash]
+              tester:
+                description: "Test engineer ensuring code quality"
+                directory: ./tests
+                model: sonnet
+                tools: [Bash, Read, Edit]
+                mcps:
+                  - name: "test_reporter"
+                    type: "sse"
+                    url: "http://localhost:9000/test-results"
+        YAML
+      end
 
-    def self.circular_connections
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Circular"
-          main: a
-          instances:
-            a:
-              description: "Instance A in circular connection"
-              connections: [b]
-            b:
-              description: "Instance B in circular connection"
-              connections: [c]
-            c:
-              description: "Instance C in circular connection"
-              connections: [a]
-      YAML
+      def circular_connections
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Circular"
+            main: a
+            instances:
+              a:
+                description: "Instance A in circular connection"
+                connections: [b]
+              b:
+                description: "Instance B in circular connection"
+                connections: [c]
+              c:
+                description: "Instance C in circular connection"
+                connections: [a]
+        YAML
+      end
     end
   end
 end

--- a/test/fixtures/swarm_configs_invalid.rb
+++ b/test/fixtures/swarm_configs_invalid.rb
@@ -2,91 +2,93 @@
 
 module Fixtures
   module SwarmConfigsInvalid
-    def self.invalid_version
-      <<~YAML
-        version: 2
-        swarm:
-          name: "Invalid"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance"
-      YAML
-    end
+    class << self
+      def invalid_version
+        <<~YAML
+          version: 2
+          swarm:
+            name: "Invalid"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance"
+        YAML
+      end
 
-    def self.missing_main
-      <<~YAML
-        version: 1
-        swarm:
-          name: "No Main"
-          instances:
-            lead:
-              description: "Lead instance"
-      YAML
-    end
+      def missing_main
+        <<~YAML
+          version: 1
+          swarm:
+            name: "No Main"
+            instances:
+              lead:
+                description: "Lead instance"
+        YAML
+      end
 
-    def self.invalid_connection
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Bad Connection"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance"
-              connections: [nonexistent]
-      YAML
-    end
+      def invalid_connection
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Bad Connection"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance"
+                connections: [nonexistent]
+        YAML
+      end
 
-    def self.missing_description
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Missing Description"
-          main: lead
-          instances:
-            lead:
-              directory: .
-      YAML
-    end
+      def missing_description
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Missing Description"
+            main: lead
+            instances:
+              lead:
+                directory: .
+        YAML
+      end
 
-    def self.tools_not_array
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Invalid Tools"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance"
-              tools: "Read"
-      YAML
-    end
+      def tools_not_array
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Invalid Tools"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance"
+                tools: "Read"
+        YAML
+      end
 
-    def self.allowed_tools_not_array
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Invalid Allowed Tools"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance"
-              allowed_tools: Edit
-      YAML
-    end
+      def allowed_tools_not_array
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Invalid Allowed Tools"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance"
+                allowed_tools: Edit
+        YAML
+      end
 
-    def self.disallowed_tools_not_array
-      <<~YAML
-        version: 1
-        swarm:
-          name: "Invalid Disallowed Tools"
-          main: lead
-          instances:
-            lead:
-              description: "Lead instance"
-              disallowed_tools: 123
-      YAML
+      def disallowed_tools_not_array
+        <<~YAML
+          version: 1
+          swarm:
+            name: "Invalid Disallowed Tools"
+            main: lead
+            instances:
+              lead:
+                description: "Lead instance"
+                disallowed_tools: 123
+        YAML
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Resolved all RuboCop style violations without disabling any cops
- All tests remain passing after fixes

## Changes
- Used `class << self` pattern for class method definitions in multiple files
- Extracted `extract_text_response` method to reduce block nesting complexity in `openai_responses.rb`
- Added `?` suffix to predicate method `execute_before_commands?` in `orchestrator.rb`
- Auto-corrected heredoc indentation in test fixtures

## Test plan
- [x] Run `bundle exec rubocop -A` - no violations
- [x] Run `bundle exec rake test` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)