### PR TITLE
feat: validate main instance cannot have provider setting

### DIFF
--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -97,6 +97,7 @@ module ClaudeSwarm
       @swarm["instances"].each do |name, config|
         @instances[name] = parse_instance(name, config)
       end
+      validate_main_instance_provider
       validate_connections
       detect_circular_dependencies
       validate_openai_env_vars
@@ -274,6 +275,13 @@ module ClaudeSwarm
         unless ENV.key?(env_var) && !ENV[env_var].to_s.strip.empty?
           raise Error, "Environment variable '#{env_var}' is not set. OpenAI provider instances require an API key."
         end
+      end
+    end
+
+    def validate_main_instance_provider
+      main_config = @instances[@main_instance]
+      if main_config[:provider]
+        raise Error, "Main instance '#{@main_instance}' cannot have a provider setting. Main instances must use Claude."
       end
     end
   end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -951,8 +951,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -963,7 +966,7 @@ class ConfigurationTest < Minitest::Test
     ENV["OPENAI_API_KEY"] = "sk-test-key"
 
     config = ClaudeSwarm::Configuration.new(@config_path)
-    assistant = config.main_instance_config
+    assistant = config.instances["ai_assistant"]
 
     assert_equal("openai", assistant[:provider])
     assert_in_delta(0.3, assistant[:temperature])
@@ -980,8 +983,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -997,7 +1003,7 @@ class ConfigurationTest < Minitest::Test
     ENV["CUSTOM_OPENAI_KEY"] = "sk-custom-test-key"
 
     config = ClaudeSwarm::Configuration.new(@config_path)
-    assistant = config.main_instance_config
+    assistant = config.instances["ai_assistant"]
 
     assert_equal("openai", assistant[:provider])
     assert_in_delta(0.7, assistant[:temperature])
@@ -1152,8 +1158,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -1174,8 +1183,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -1193,13 +1205,104 @@ class ConfigurationTest < Minitest::Test
     ENV.delete("OPENAI_API_KEY")
   end
 
+  def test_main_instance_must_be_claude
+    write_config(<<~YAML)
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Main instance with OpenAI provider"
+            provider: openai
+            model: gpt-4o
+    YAML
+
+    # Set the required environment variable
+    ENV["OPENAI_API_KEY"] = "test-key"
+
+    error = assert_raises(ClaudeSwarm::Error) do
+      ClaudeSwarm::Configuration.new(@config_path)
+    end
+    assert_equal("Main instance 'lead' cannot have a provider setting. Main instances must use Claude.", error.message)
+  ensure
+    ENV.delete("OPENAI_API_KEY")
+  end
+
+  def test_main_instance_with_explicit_claude_provider
+    write_config(<<~YAML)
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Main instance with explicit Claude provider"
+            provider: claude
+    YAML
+
+    # Should raise an error because main instance can't have provider
+    error = assert_raises(ClaudeSwarm::Error) do
+      ClaudeSwarm::Configuration.new(@config_path)
+    end
+    assert_equal("Main instance 'lead' cannot have a provider setting. Main instances must use Claude.", error.message)
+  end
+
+  def test_main_instance_without_provider_defaults_to_claude
+    write_config(<<~YAML)
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Main instance without provider"
+    YAML
+
+    # Should not raise an error
+    config = ClaudeSwarm::Configuration.new(@config_path)
+
+    assert_nil(config.main_instance_config[:provider])
+  end
+
+  def test_non_main_instance_can_use_openai_provider
+    write_config(<<~YAML)
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Main instance with Claude"
+            connections: [assistant]
+          assistant:
+            description: "Assistant with OpenAI provider"
+            provider: openai
+            model: gpt-4o
+    YAML
+
+    # Set the required environment variable
+    ENV["OPENAI_API_KEY"] = "test-key"
+
+    # Should not raise an error
+    config = ClaudeSwarm::Configuration.new(@config_path)
+
+    assert_nil(config.main_instance_config[:provider])
+    assert_equal("openai", config.instances["assistant"][:provider])
+  ensure
+    ENV.delete("OPENAI_API_KEY")
+  end
+
   def test_openai_instance_with_whitespace_api_key_env_var
     write_config(<<~YAML)
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -1222,8 +1325,10 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -1245,8 +1350,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: ai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [ai_assistant]
           ai_assistant:
             description: "OpenAI-powered assistant"
             provider: openai
@@ -1258,7 +1366,7 @@ class ConfigurationTest < Minitest::Test
 
     # Should not raise any errors
     config = ClaudeSwarm::Configuration.new(@config_path)
-    assistant = config.main_instance_config
+    assistant = config.instances["ai_assistant"]
 
     assert_equal("openai", assistant[:provider])
   ensure
@@ -1611,8 +1719,11 @@ class ConfigurationTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            connections: [assistant]
           assistant:
             description: "OpenAI assistant"
             provider: openai
@@ -1622,7 +1733,7 @@ class ConfigurationTest < Minitest::Test
     YAML
 
     config = ClaudeSwarm::Configuration.new(@config_path)
-    assistant = config.main_instance_config
+    assistant = config.instances["assistant"]
 
     assert_equal("CUSTOM_API_KEY", assistant[:openai_token_env])
     assert_equal("https://custom.openai.com/v1", assistant[:base_url])

--- a/test/mcp_generator_test.rb
+++ b/test/mcp_generator_test.rb
@@ -421,8 +421,12 @@ class McpGeneratorTest < Minitest::Test
       version: 1
       swarm:
         name: "Test Swarm"
-        main: openai_assistant
+        main: lead
         instances:
+          lead:
+            description: "Claude lead"
+            directory: .
+            connections: [openai_assistant]
           openai_assistant:
             description: "OpenAI instance"
             directory: .


### PR DESCRIPTION
## Summary
- Added validation to ensure main instances cannot have a provider setting
- Main instances must use Claude and cannot specify any provider (including explicit `claude`)
- Added comprehensive tests covering all validation scenarios
- Fixed existing tests that incorrectly used OpenAI provider for main instances

## Changes Made
1. **Configuration Validation**: Added `validate_main_instance_provider` method to check main instance configuration
2. **Error Handling**: Clear error message when main instance has provider setting
3. **Test Coverage**: Added tests for:
   - Main instance with OpenAI provider (should fail)
   - Main instance with explicit Claude provider (should fail)
   - Main instance without provider (should succeed)
   - Non-main instances can still use OpenAI provider
4. **Test Fixes**: Updated existing tests to use proper swarm topology with Claude main instances

## Test Plan
- [x] All existing tests pass
- [x] New validation tests cover edge cases
- [x] Main instances correctly default to Claude when no provider specified
- [x] Non-main instances can still use OpenAI provider
- [x] Clear error messages for invalid configurations

🤖 Generated with [Claude Code](https://claude.ai/code)