### PR TITLE
Refactor: Consolidate requires using Zeitwerk autoloading

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,3 +152,47 @@ The gem includes comprehensive tests covering:
 
 - **thor** (~> 1.3): Command-line interface framework
 - **yaml**: Built-in Ruby YAML parser (no explicit dependency needed)
+
+## Zeitwerk Autoloading
+
+This project uses Zeitwerk for automatic class loading. Important guidelines:
+
+### Require Statement Rules
+
+1. **DO NOT include any require statements for lib files**: Zeitwerk automatically loads all classes under `lib/claude_swarm/`. Never use `require`, `require_relative`, or `require "claude_swarm/..."` for internal project files.
+
+2. **All dependencies must be consolidated in lib/claude_swarm.rb**: Both standard library and external gem dependencies are required at the top of `lib/claude_swarm.rb`. This includes:
+   - Standard library dependencies (json, yaml, fileutils, etc.)
+   - External gem dependencies (thor, openai, mcp_client, fast_mcp_annotations)
+
+3. **No requires in other lib files**: Individual files in `lib/claude_swarm/` should not have any require statements. They rely on:
+   - Dependencies loaded in `lib/claude_swarm.rb`
+   - Other classes autoloaded by Zeitwerk
+
+### Example
+
+```ruby
+# ✅ CORRECT - lib/claude_swarm.rb
+# Standard library dependencies
+require "json"
+require "yaml"
+require "fileutils"
+# ... other standard libraries
+
+# External dependencies
+require "thor"
+require "openai"
+# ... other gems
+
+# Zeitwerk setup
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem
+loader.setup
+
+# ❌ INCORRECT - lib/claude_swarm/some_class.rb
+require "json"  # Don't do this!
+require_relative "other_class"  # Don't do this!
+require "claude_swarm/configuration"  # Don't do this!
+```
+
+This approach ensures clean dependency management and leverages Ruby's modern autoloading capabilities.

--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -1,17 +1,29 @@
 # frozen_string_literal: true
 
-# External dependencies
-require "time"
-require "thor"
-require "yaml"
-require "json"
-require "fileutils"
+# Standard library dependencies
+require "digest"
+require "English"
 require "erb"
-require "tmpdir"
-require "open3"
-require "timeout"
-require "pty"
+require "fileutils"
 require "io/console"
+require "json"
+require "logger"
+require "open3"
+require "pathname"
+require "pty"
+require "securerandom"
+require "set"
+require "shellwords"
+require "time"
+require "timeout"
+require "tmpdir"
+require "yaml"
+
+# External dependencies
+require "fast_mcp_annotations"
+require "mcp_client"
+require "openai"
+require "thor"
 
 # Zeitwerk setup
 require "zeitwerk"

--- a/lib/claude_swarm/claude_code_executor.rb
+++ b/lib/claude_swarm/claude_code_executor.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "open3"
-require "logger"
-require "fileutils"
-
 module ClaudeSwarm
   class ClaudeCodeExecutor
     attr_reader :session_id, :last_response, :working_directory, :logger, :session_path

--- a/lib/claude_swarm/claude_mcp_server.rb
+++ b/lib/claude_swarm/claude_mcp_server.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "fast_mcp_annotations"
-require "json"
-
 module ClaudeSwarm
   class ClaudeMcpServer
     # Class variables to share state with tool classes

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "thor"
-require "json"
-require "erb"
-
 module ClaudeSwarm
   class CLI < Thor
     include SystemUtils

--- a/lib/claude_swarm/commands/ps.rb
+++ b/lib/claude_swarm/commands/ps.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "yaml"
-require "json"
-require "time"
-require_relative "../session_cost_calculator"
-
 module ClaudeSwarm
   module Commands
     class Ps

--- a/lib/claude_swarm/commands/show.rb
+++ b/lib/claude_swarm/commands/show.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "yaml"
-require "json"
-require "time"
-require_relative "../session_cost_calculator"
-
 module ClaudeSwarm
   module Commands
     class Show

--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "yaml"
-require "pathname"
-
 module ClaudeSwarm
   class Configuration
     attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "fileutils"
-require "shellwords"
-require "securerandom"
-
 module ClaudeSwarm
   class McpGenerator
     def initialize(configuration, vibe: false, restore_session_path: nil)

--- a/lib/claude_swarm/openai_chat_completion.rb
+++ b/lib/claude_swarm/openai_chat_completion.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "logger"
-require "securerandom"
-
 module ClaudeSwarm
   class OpenAIChatCompletion
     MAX_TURNS_WITH_TOOLS = 100_000 # virtually infinite

--- a/lib/claude_swarm/openai_executor.rb
+++ b/lib/claude_swarm/openai_executor.rb
@@ -1,14 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "logger"
-require "fileutils"
-require "openai"
-require "mcp_client"
-require "securerandom"
-require_relative "openai_chat_completion"
-require_relative "openai_responses"
-
 module ClaudeSwarm
   class OpenAIExecutor
     attr_reader :session_id, :last_response, :working_directory, :logger, :session_path

--- a/lib/claude_swarm/openai_responses.rb
+++ b/lib/claude_swarm/openai_responses.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "logger"
-require "securerandom"
-
 module ClaudeSwarm
   class OpenAIResponses
     MAX_TURNS_WITH_TOOLS = 100_000 # virtually infinite

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -1,11 +1,5 @@
 # frozen_string_literal: true
 
-require "English"
-require "shellwords"
-require "json"
-require "fileutils"
-require_relative "session_cost_calculator"
-
 module ClaudeSwarm
   class Orchestrator
     include SystemUtils

--- a/lib/claude_swarm/process_tracker.rb
+++ b/lib/claude_swarm/process_tracker.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
 module ClaudeSwarm
   class ProcessTracker
     PIDS_DIR = "pids"

--- a/lib/claude_swarm/session_cost_calculator.rb
+++ b/lib/claude_swarm/session_cost_calculator.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
-require "set"
-
 module ClaudeSwarm
   module SessionCostCalculator
     extend self

--- a/lib/claude_swarm/session_path.rb
+++ b/lib/claude_swarm/session_path.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
 module ClaudeSwarm
   module SessionPath
     SESSIONS_DIR = "sessions"

--- a/lib/claude_swarm/system_utils.rb
+++ b/lib/claude_swarm/system_utils.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "English"
-
 module ClaudeSwarm
   module SystemUtils
     def system!(*args)

--- a/lib/claude_swarm/worktree_manager.rb
+++ b/lib/claude_swarm/worktree_manager.rb
@@ -1,12 +1,5 @@
 # frozen_string_literal: true
 
-require "open3"
-require "fileutils"
-require "json"
-require "pathname"
-require "securerandom"
-require "digest"
-
 module ClaudeSwarm
   class WorktreeManager
     include SystemUtils

--- a/test/claude_code_executor_test.rb
+++ b/test/claude_code_executor_test.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/claude_code_executor"
-require "tmpdir"
-require "fileutils"
-require "stringio"
 
 class ClaudeCodeExecutorTest < Minitest::Test
   def setup

--- a/test/claude_mcp_server_test.rb
+++ b/test/claude_mcp_server_test.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/claude_mcp_server"
-require "claude_swarm/task_tool"
-require "claude_swarm/session_info_tool"
-require "claude_swarm/reset_session_tool"
-require "tmpdir"
-require "fileutils"
-require "stringio"
 
 class ClaudeMcpServerTest < Minitest::Test
   def setup

--- a/test/claude_mcp_server_test.rb.bak
+++ b/test/claude_mcp_server_test.rb.bak
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/claude_mcp_server"
-require "tmpdir"
-require "fileutils"
-require "stringio"
 
 class ClaudeMcpServerTest < Minitest::Test
   def setup

--- a/test/cleanup_integration_test.rb
+++ b/test/cleanup_integration_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
-require "timeout"
 
 class CleanupIntegrationTest < Minitest::Test
   def setup

--- a/test/cli_commands_test.rb
+++ b/test/cli_commands_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/cli"
 
 module ClaudeSwarm
   class CLICommandsTest < Minitest::Test

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/cli"
-require "tmpdir"
-require "fileutils"
 
 class CLITest < Minitest::Test
   def setup

--- a/test/commands/ps_test.rb
+++ b/test/commands/ps_test.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/commands/ps"
-require "fileutils"
-require "yaml"
-require "json"
-
 module ClaudeSwarm
   module Commands
     class PsTest < Minitest::Test

--- a/test/commands/show_test.rb
+++ b/test/commands/show_test.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/commands/show"
-require "fileutils"
-require "yaml"
 
 module ClaudeSwarm
   module Commands

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/configuration"
-require "tmpdir"
-require "fileutils"
 
 class ConfigurationTest < Minitest::Test
   def setup

--- a/test/configuration_vibe_test.rb
+++ b/test/configuration_vibe_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/configuration"
 
 class ConfigurationVibeTest < Minitest::Test
   def setup

--- a/test/integration_restoration_test.rb
+++ b/test/integration_restoration_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
-require "json"
 
 class IntegrationRestorationTest < Minitest::Test
   def setup

--- a/test/mcp_generator_args_test.rb
+++ b/test/mcp_generator_args_test.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/configuration"
-require "claude_swarm/mcp_generator"
-require "json"
-require "tmpdir"
 
 class McpGeneratorArgsTest < Minitest::Test
   def setup

--- a/test/mcp_generator_test.rb
+++ b/test/mcp_generator_test.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/configuration"
-require "claude_swarm/mcp_generator"
-require "tmpdir"
-require "fileutils"
-require "json"
 
 class McpGeneratorTest < Minitest::Test
   def setup

--- a/test/mcp_generator_vibe_test.rb
+++ b/test/mcp_generator_vibe_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/configuration"
-require "claude_swarm/mcp_generator"
 
 class McpGeneratorVibeTest < Minitest::Test
   def setup

--- a/test/openai_executor_test.rb
+++ b/test/openai_executor_test.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/openai_executor"
-require "tmpdir"
-require "fileutils"
 
 class OpenAIExecutorTest < Minitest::Test
   def setup

--- a/test/openai_integration_test.rb
+++ b/test/openai_integration_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/openai_chat_completion"
-require "claude_swarm/openai_responses"
 
 class OpenAIIntegrationTest < Minitest::Test
   def test_chat_completion_simple_message

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/orchestrator"
-require "claude_swarm/configuration"
-require "claude_swarm/mcp_generator"
-require "tmpdir"
-require "fileutils"
 
 class OrchestratorTest < Minitest::Test
   def setup

--- a/test/orchestrator_worktree_cleanup_test.rb
+++ b/test/orchestrator_worktree_cleanup_test.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../lib/claude_swarm/orchestrator"
-require_relative "../lib/claude_swarm/configuration"
-require_relative "../lib/claude_swarm/mcp_generator"
-require "digest"
 
 class OrchestratorWorktreeCleanupTest < Minitest::Test
   def setup

--- a/test/orchestrator_worktree_integration_test.rb
+++ b/test/orchestrator_worktree_integration_test.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../lib/claude_swarm/orchestrator"
-require_relative "../lib/claude_swarm/configuration"
-require_relative "../lib/claude_swarm/mcp_generator"
-require "digest"
 
 class OrchestratorWorktreeIntegrationTest < Minitest::Test
   def setup

--- a/test/orchestrator_worktree_restoration_test.rb
+++ b/test/orchestrator_worktree_restoration_test.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../lib/claude_swarm/orchestrator"
-require_relative "../lib/claude_swarm/configuration"
-require_relative "../lib/claude_swarm/mcp_generator"
-require "digest"
-require "json"
 
 class OrchestratorWorktreeRestorationTest < Minitest::Test
   def setup

--- a/test/process_tracker_test.rb
+++ b/test/process_tracker_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
 
 class ProcessTrackerTest < Minitest::Test
   def setup

--- a/test/session_path_test.rb
+++ b/test/session_path_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "claude_swarm/session_path"
 
 class SessionPathTest < Minitest::Test
   def test_project_folder_name_unix_path

--- a/test/session_restoration_test.rb
+++ b/test/session_restoration_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
-require "json"
 
 class SessionRestorationTest < Minitest::Test
   def setup

--- a/test/session_state_concurrency_test.rb
+++ b/test/session_state_concurrency_test.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
-require "json"
-
 class SessionStateConcurrencyTest < Minitest::Test
   def setup
     @test_dir = Dir.mktmpdir

--- a/test/working_directory_behavior_test.rb
+++ b/test/working_directory_behavior_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
 
 class WorkingDirectoryBehaviorTest < Minitest::Test
   def setup

--- a/test/working_directory_restoration_test.rb
+++ b/test/working_directory_restoration_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require "tmpdir"
-require "json"
 
 class WorkingDirectoryRestorationTest < Minitest::Test
   def setup

--- a/test/worktree_manager_test.rb
+++ b/test/worktree_manager_test.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require "test_helper"
-require_relative "../lib/claude_swarm/worktree_manager"
-require "digest"
 
 class WorktreeManagerTest < Minitest::Test
   def setup


### PR DESCRIPTION
## Summary
- Removes all manual require statements for internal project files
- Consolidates all standard library and external gem dependencies in `lib/claude_swarm.rb`
- Adds comprehensive Zeitwerk documentation to CLAUDE.md

## Changes

### Require Statement Cleanup
- ✅ Removed all `require_relative` statements from lib files (5 occurrences)
- ✅ Removed all `require "claude_swarm/..."` statements from test files (20 occurrences)
- ✅ Removed all standard library requires from individual lib files (16 files modified)

### Dependency Consolidation
All dependencies are now centralized in `lib/claude_swarm.rb`:
- Standard library: digest, English, erb, fileutils, io/console, json, logger, open3, pathname, pty, securerandom, set, shellwords, time, timeout, tmpdir, yaml
- External gems: fast_mcp_annotations, mcp_client, openai, thor

### Documentation
Added a new "Zeitwerk Autoloading" section to CLAUDE.md with:
- Clear guidelines about not including require statements for lib files
- Instructions for dependency management
- Examples of correct vs incorrect usage

### RuboCop Configuration
- Disabled `Style/SpecialGlobalVars` cop to allow using `$?` instead of `$CHILD_STATUS`

## Test Results
All tests pass successfully with these changes, confirming that:
- Zeitwerk autoloading works correctly for all internal classes
- All dependencies are properly loaded from the central location
- The gem functions as expected

## Benefits
1. **Cleaner codebase**: No manual require management for internal files
2. **Single source of truth**: All dependencies in one place
3. **Modern Ruby practices**: Leverages Zeitwerk's automatic loading
4. **Easier maintenance**: Adding new classes doesn't require updating requires

🤖 Generated with [Claude Code](https://claude.ai/code)