### PR TITLE
fix: suppress test output in test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,15 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
     
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+    - name: Install Claude Code
+      run: npm install -g @anthropic-ai/claude-code
     
     - name: Run tests and linter
       run: bundle exec rake

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,23 @@ bin/setup              # Install dependencies
 rake test             # Run the Minitest test suite
 ```
 
+**Important**: Tests should not generate any output to stdout or stderr. When writing tests:
+- Capture or suppress all stdout/stderr output from tested methods
+- Use `capture_io` or `capture_subprocess_io` for Minitest
+- Redirect output streams to `StringIO` or `/dev/null` when necessary
+- Mock or stub methods that produce console output
+- Ensure clean test output for better CI/CD integration
+
+Example:
+```ruby
+def test_command_with_output
+  output, err = capture_io do
+    # Code that produces output
+  end
+  # Test assertions here
+end
+```
+
 ### Linting
 ```bash
 rake rubocop -A       # Run RuboCop linter to auto fix problems

--- a/test/cleanup_integration_test.rb
+++ b/test/cleanup_integration_test.rb
@@ -23,6 +23,7 @@ class CleanupIntegrationTest < Minitest::Test
         main: leader
         instances:
           leader:
+            description: "Test leader instance"
             directory: #{@temp_dir}
             model: sonnet
             prompt: "You are a test leader"
@@ -34,15 +35,11 @@ class CleanupIntegrationTest < Minitest::Test
 
     # Start the swarm in a subprocess
     pid = fork do
-      # Redirect output to avoid cluttering test output
-      $stdout = File.open(File::NULL, "w")
-      $stderr = File.open(File::NULL, "w")
-
       # Set up a simple test environment
       ENV["CLAUDE_SWARM_TEST"] = "1"
 
       # Run claude-swarm with a prompt that exits immediately
-      system("bundle", "exec", "claude-swarm", "-c", @config_file, "-p", "exit")
+      system("bundle", "exec", "claude-swarm", "-c", @config_file, "-p", "exit", out: File::NULL, err: File::NULL)
     end
 
     # Give it time to start

--- a/test/orchestrator_worktree_integration_test.rb
+++ b/test/orchestrator_worktree_integration_test.rb
@@ -35,7 +35,7 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
 
       # Start the orchestrator and capture the worktree path
       orchestrator.stub(:system, true) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       # Get the worktree info from the manager
@@ -75,7 +75,7 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
         worktree_name = orchestrator.instance_variable_get(:@worktree_manager).worktree_name
         true
       }) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       # Verify worktree name was auto-generated with session ID
@@ -93,7 +93,7 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
       )
 
       orchestrator.stub(:system, true) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       # Check no worktrees were created
@@ -128,7 +128,7 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
         end
         true
       }) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       assert(cleanup_called, "Worktree cleanup should be called")

--- a/test/orchestrator_worktree_restoration_test.rb
+++ b/test/orchestrator_worktree_restoration_test.rb
@@ -129,7 +129,7 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
         worktree_dir_used = Dir.pwd
         true
       }) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       # Verify the main instance started in the external worktree
@@ -171,7 +171,7 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
         dir_used = Dir.pwd
         true
       }) do
-        orchestrator.start
+        capture_io { orchestrator.start }
       end
 
       # Verify the main instance started in the regular directory

--- a/test/process_tracker_test.rb
+++ b/test/process_tracker_test.rb
@@ -49,7 +49,7 @@ class ProcessTrackerTest < Minitest::Test
     @tracker.track_pid(12_345, "test_process")
 
     assert_path_exists(@pids_dir)
-    @tracker.cleanup_all
+    capture_io { @tracker.cleanup_all }
 
     refute_path_exists(@pids_dir, "pids directory should be removed after cleanup")
   end


### PR DESCRIPTION
## Summary
- Fixed test output leak in `cleanup_integration_test.rb` by adding missing 'description' field
- Updated CLAUDE.md with comprehensive testing guidelines for output suppression
- Ensures clean test output for better CI/CD integration

## Test plan
- [x] Run `bundle exec rake test` and verify no output is printed to console
- [x] Run specific test `bundle exec ruby -Itest test/cleanup_integration_test.rb` to verify it passes
- [x] Verify the error message "Instance 'leader' missing required 'description' field" no longer appears
- [x] CI now has Claude Code installed.

🤖 Generated with [Claude Code](https://claude.ai/code)