### PR TITLE
Add SimpleCov for code coverage tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ build/
 .claude/settings.local.json
 .react-router/
 .vite/
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.0", require: false
 
 gem "minitest", "~> 5.16", require: false
 gem "webmock", "~> 3.0", require: false
+gem "simplecov", "~> 0.22", require: false
 
 gem "rubocop-shopify", require: false
 gem "rubocop-performance", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
       bigdecimal
       rexml
     date (3.4.1)
+    docile (1.4.1)
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -194,6 +195,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.1)
+    simplecov_json_formatter (0.1.4)
     sinatra (3.2.0)
       mustermann (~> 3.0)
       rack (~> 2.2, >= 2.2.4)
@@ -236,6 +243,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rake
   rubocop-shopify
+  simplecov (~> 0.22)
   webmock (~> 3.0)
 
 BUNDLED WITH

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
-require "claude_swarm"
+require "simplecov"
+SimpleCov.start do
+  add_filter "/test/"
+  add_filter "/vendor/"
+  add_filter "/version.rb"
+  add_group "Library", "lib"
+  track_files "{lib}/**/*.rb"
+end
 
+$LOAD_PATH.unshift(File.expand_path("../lib", __dir__))
+
+require "claude_swarm"
 require "minitest/autorun"
 require_relative "fixtures/swarm_configs"
 require_relative "helpers/test_helpers"


### PR DESCRIPTION
## Summary
- Added SimpleCov gem for code coverage tracking
- Configured coverage reports to exclude test files, vendor files, and version.rb
- Coverage reports will be generated in the `/coverage` directory (already gitignored)

## Test plan
- [x] Add SimpleCov to Gemfile
- [x] Configure SimpleCov in test_helper.rb
- [x] Verify coverage directory is in .gitignore
- [ ] Run `bundle install` to install SimpleCov
- [ ] Run `bundle exec rake test` to generate coverage report
- [ ] Open `coverage/index.html` to view coverage metrics

🤖 Generated with [Claude Code](https://claude.ai/code)