### PR TITLE
Add claude-swarm wrapper gem for alternative naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,15 @@ jobs:
         gem push *.gem
       env:
         GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}
+    
+    - name: Build wrapper gem
+      run: |
+        cd claude-swarm-wrapper
+        gem build *.gemspec
+    
+    - name: Push wrapper gem to RubyGems
+      run: |
+        cd claude-swarm-wrapper
+        gem push *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_AUTH_TOKEN}}

--- a/claude-swarm-wrapper/README.md
+++ b/claude-swarm-wrapper/README.md
@@ -1,0 +1,27 @@
+# claude-swarm
+
+This is an alias gem for [claude_swarm](https://github.com/parruda/claude-swarm).
+
+## Installation
+
+You can install using either name:
+
+```bash
+gem install claude-swarm
+# or
+gem install claude_swarm
+```
+
+Both will give you the same functionality.
+
+## Usage
+
+See the main [claude_swarm documentation](https://github.com/parruda/claude-swarm) for usage instructions.
+
+## Why this gem exists
+
+Some users prefer hyphenated gem names (`claude-swarm`) while others prefer underscored names (`claude_swarm`). This wrapper gem allows you to use whichever naming convention you prefer.
+
+## License
+
+MIT License - Same as claude_swarm

--- a/claude-swarm-wrapper/Rakefile
+++ b/claude-swarm-wrapper/Rakefile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "bundler/gem_tasks"
+
+task default: []

--- a/claude-swarm-wrapper/claude-swarm.gemspec
+++ b/claude-swarm-wrapper/claude-swarm.gemspec
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "claude_swarm"
+
+Gem::Specification.new do |spec|
+  spec.name = "claude-swarm"
+  spec.version = ClaudeSwarm::VERSION
+  spec.authors = ["Paulo Arruda"]
+  spec.email = ["parrudaj@gmail.com"]
+
+  spec.summary = "Alias gem for claude_swarm - Orchestrate multiple Claude Code instances"
+  spec.description = <<~DESC
+    This is an alias gem for claude_swarm. Install this if you prefer the hyphenated name.
+
+    Claude Swarm enables you to run multiple Claude Code instances that communicate with each other
+    via MCP (Model Context Protocol). Create AI development teams where each instance has specialized
+    roles, tools, and directory contexts.
+  DESC
+  spec.homepage = "https://github.com/parruda/claude-swarm"
+  spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.2.0"
+
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/parruda/claude-swarm"
+  spec.metadata["changelog_uri"] = "https://github.com/parruda/claude-swarm/blob/main/CHANGELOG.md"
+
+  spec.files = ["lib/claude-swarm.rb", "claude-swarm.gemspec", "README.md"]
+  spec.require_paths = ["lib"]
+
+  # This gem simply depends on the main claude_swarm gem
+  spec.add_dependency("claude_swarm")
+end

--- a/claude-swarm-wrapper/lib/claude-swarm.rb
+++ b/claude-swarm-wrapper/lib/claude-swarm.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# This is a wrapper gem that simply requires claude_swarm
+# Users can install either 'claude-swarm' or 'claude_swarm' and get the same functionality
+require "claude_swarm"


### PR DESCRIPTION
## Summary
- Create wrapper gem that allows installation via `gem install claude-swarm`
- Update release workflow to automatically publish both gems
- Users can now choose their preferred naming convention

## Test plan
- [ ] Verify the wrapper gem builds successfully
- [ ] Test that `require "claude-swarm"` correctly loads claude_swarm
- [ ] Ensure release workflow runs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)