### PR TITLE
feat: switch session IDs from timestamp to UUID format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Changed
+- **Session ID format**: Session IDs now use UUIDs instead of timestamp format
+  - Previous format: `YYYYMMDD_HHMMSS` (e.g., `20250707_181341`)
+  - New format: UUID v4 (e.g., `550e8400-e29b-41d4-a716-446655440000`)
+  - Provides globally unique identifiers suitable for external application integration
+  - Sessions remain sorted by file creation time, not by ID
+
 ### Added
 - **Environment variable interpolation in configuration**: Claude Swarm now supports environment variable interpolation in all YAML configuration values
   - Use `${ENV_VAR_NAME}` syntax to reference environment variables

--- a/README.md
+++ b/README.md
@@ -825,10 +825,10 @@ Resume a previous session with all instances restored to their Claude session st
 
 ```bash
 # Resume by session ID
-claude-swarm --session-id 20250617_143022
+claude-swarm --session-id 550e8400-e29b-41d4-a716-446655440000
 
 # Resume by full path
-claude-swarm --session-id ~/.claude-swarm/sessions/my-project/20250617_143022
+claude-swarm --session-id ~/.claude-swarm/sessions/my-project/550e8400-e29b-41d4-a716-446655440000
 ```
 
 This will:
@@ -900,7 +900,7 @@ The swarm will display:
 
 ### Session Files
 
-Check the session directory `~/.claude-swarm/sessions/{project}/{timestamp}/` for:
+Check the session directory `~/.claude-swarm/sessions/{project}/{session-id}/` for:
 - `session.log`: Human-readable logs with request/response tracking
 - `session.log.json`: All events in JSONL format (one JSON object per line)
 - `{instance}.mcp.json`: MCP configuration for each instance

--- a/lib/claude_swarm/session_path.rb
+++ b/lib/claude_swarm/session_path.rb
@@ -24,10 +24,10 @@ module ClaudeSwarm
         path.gsub(%r{[/\\]}, "+")
       end
 
-      # Generate a full session path for a given directory and timestamp
-      def generate(working_dir: Dir.pwd, timestamp: Time.now.strftime("%Y%m%d_%H%M%S"))
+      # Generate a full session path for a given directory and session ID
+      def generate(working_dir: Dir.pwd, session_id: SecureRandom.uuid)
         project_name = project_folder_name(working_dir)
-        File.join(swarm_home, SESSIONS_DIR, project_name, timestamp)
+        File.join(swarm_home, SESSIONS_DIR, project_name, session_id)
       end
 
       # Ensure the session directory exists

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -72,7 +72,7 @@ class OrchestratorTest < Minitest::Test
 
     assert(ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil))
     assert(ENV.fetch("CLAUDE_SWARM_START_DIR", nil))
-    assert_match(%r{/sessions/.+/\d{8}_\d{6}}, ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil))
+    assert_match(%r{/sessions/.+/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil))
   end
 
   def test_start_generates_mcp_configs
@@ -107,7 +107,7 @@ class OrchestratorTest < Minitest::Test
     end
 
     assert_match(/🐝 Starting Claude Swarm: Test Swarm/, output)
-    assert_match(%r{📝 Session files will be saved to:.*/sessions/.+/\d{8}_\d{6}}, output)
+    assert_match(%r{📝 Session files will be saved to:.*/sessions/.+/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}, output)
     assert_match(/✓ Generated MCP configurations/, output)
     assert_match(/🚀 Launching main instance: lead/, output)
     assert_match(/Model: opus/, output)

--- a/test/orchestrator_worktree_integration_test.rb
+++ b/test/orchestrator_worktree_integration_test.rb
@@ -74,8 +74,8 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
         capture_io { orchestrator.start }
       end
 
-      # Verify worktree name was auto-generated with session ID
-      assert_match(/^worktree-\d{8}_\d{6}$/, worktree_name)
+      # Verify worktree name was auto-generated with session ID (UUID format)
+      assert_match(/^worktree-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/, worktree_name)
 
       # Worktree name should have been captured
       assert(worktree_name, "Worktree name should be captured")

--- a/test/session_path_test.rb
+++ b/test/session_path_test.rb
@@ -28,15 +28,22 @@ class SessionPathTest < Minitest::Test
   end
 
   def test_generate_session_path
-    timestamp = "20240101_120000"
+    session_id = "550e8400-e29b-41d4-a716-446655440000"
     result = ClaudeSwarm::SessionPath.generate(
       working_dir: "/Users/paulo/test",
-      timestamp: timestamp,
+      session_id: session_id,
     )
 
-    expected = File.join(ClaudeSwarm::SessionPath.swarm_home, "sessions/Users+paulo+test/20240101_120000")
+    expected = File.join(ClaudeSwarm::SessionPath.swarm_home, "sessions/Users+paulo+test/550e8400-e29b-41d4-a716-446655440000")
 
     assert_equal(expected, result)
+  end
+
+  def test_generate_session_path_with_default_uuid
+    result = ClaudeSwarm::SessionPath.generate(working_dir: "/Users/paulo/test")
+
+    # Check that the path includes a UUID-formatted session ID
+    assert_match(%r{sessions/Users\+paulo\+test/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$}, result)
   end
 
   def test_from_env_with_path_set


### PR DESCRIPTION
## Summary
- Replace timestamp-based session IDs with UUIDs for better uniqueness and external application integration
- Session IDs are now globally unique and suitable for database storage
- No breaking changes to existing functionality

## Changes
- Update `SessionPath.generate` to use `SecureRandom.uuid` instead of timestamp format
- Update all tests to expect UUID format
- Update documentation (README and CHANGELOG)

## Motivation
This change was requested to make sessions easier to discover and manage from external applications. UUIDs provide:
- Global uniqueness (no collision risk even with concurrent launches)
- Stable identifiers suitable for database storage
- Better integration with external UIs and monitoring tools

## Before/After
**Before**: `~/.claude-swarm/sessions/project-name/20250707_181341/`
**After**: `~/.claude-swarm/sessions/project-name/550e8400-e29b-41d4-a716-446655440000/`

## Test plan
- [x] All existing tests pass
- [x] RuboCop linter shows no issues
- [x] Sessions are still sorted by file creation time (not by ID)
- [x] Session restoration works with new UUID format

🤖 Generated with [Claude Code](https://claude.ai/code)