### PR TITLE
feat: add --session-id option to start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   - Existing swarms relying on before commands running in the original directory will need to be updated
 
 ### Added
+- **Custom session ID support**: Added `--session-id` option to the `start` command to allow users to specify their own session ID
+  - Use `claude-swarm start --session-id my-custom-id` to use a custom session ID
+  - If not provided, a UUID is generated automatically
+  - Useful for integrating with external systems that need predictable session identifiers
 - **Environment variable interpolation in configuration**: Claude Swarm now supports environment variable interpolation in all YAML configuration values
   - Use `${ENV_VAR_NAME}` syntax to reference environment variables
   - Variables are interpolated recursively in strings, arrays, and nested structures

--- a/README.md
+++ b/README.md
@@ -700,9 +700,11 @@ claude-swarm --vibe
 claude-swarm -p "Implement the new user authentication feature"
 claude-swarm --prompt "Fix the bug in the payment module"
 
-# Resume a previous session by ID
-claude-swarm --session-id 20241206_143022
-claude-swarm --session-id ~/path/to/session
+# Use a custom session ID instead of auto-generated UUID
+claude-swarm --session-id my-custom-session-123
+
+# Stream logs to stdout in prompt mode
+claude-swarm -p "Fix the tests" --stream-logs
 
 # Run all instances in Git worktrees
 claude-swarm --worktree                  # Auto-generated name (worktree-SESSION_ID)
@@ -826,6 +828,7 @@ Output shows:
 Resume a previous session with all instances restored to their Claude session states:
 
 ```bash
+# Restore using the session's UUID
 claude-swarm restore 550e8400-e29b-41d4-a716-446655440000
 ```
 

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -31,6 +31,9 @@ module ClaudeSwarm
       aliases: "-w",
       desc: "Create instances in Git worktrees with the given name (auto-generated if true)",
       banner: "[NAME]"
+    method_option :session_id,
+      type: :string,
+      desc: "Use a specific session ID instead of generating one"
     def start(config_file = nil)
       config_path = config_file || "claude-swarm.yml"
       unless File.exist?(config_path)
@@ -57,6 +60,7 @@ module ClaudeSwarm
           stream_logs: options[:stream_logs],
           debug: options[:debug],
           worktree: options[:worktree],
+          session_id: options[:session_id],
         )
         orchestrator.start
       rescue Error => e
@@ -541,6 +545,7 @@ module ClaudeSwarm
           debug: options[:debug],
           restore_session_path: session_path,
           worktree: worktree_name,
+          session_id: options[:session_id],
         )
         orchestrator.start
       rescue StandardError => e

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -6,7 +6,7 @@ module ClaudeSwarm
     RUN_DIR = File.expand_path("~/.claude-swarm/run")
 
     def initialize(configuration, mcp_generator, vibe: false, prompt: nil, stream_logs: false, debug: false,
-      restore_session_path: nil, worktree: nil)
+      restore_session_path: nil, worktree: nil, session_id: nil)
       @config = configuration
       @generator = mcp_generator
       @vibe = vibe
@@ -15,6 +15,7 @@ module ClaudeSwarm
       @debug = debug
       @restore_session_path = restore_session_path
       @session_path = nil
+      @provided_session_id = session_id
       # Store worktree option for later use
       @worktree_option = worktree
       @needs_worktree_manager = worktree.is_a?(String) || worktree == "" ||
@@ -76,7 +77,11 @@ module ClaudeSwarm
         end
 
         # Generate and set session path for all instances
-        session_path = SessionPath.generate(working_dir: Dir.pwd)
+        session_path = if @provided_session_id
+          SessionPath.generate(working_dir: Dir.pwd, session_id: @provided_session_id)
+        else
+          SessionPath.generate(working_dir: Dir.pwd)
+        end
         SessionPath.ensure_directory(session_path)
         @session_path = session_path
 


### PR DESCRIPTION
## Summary

This PR adds a new `--session-id` option to the `start` command that allows users to specify custom session identifiers instead of relying on auto-generated UUIDs.

### Changes Made

- Added `--session-id` option to the CLI `start` command in `lib/claude_swarm/cli.rb`
- Modified `Orchestrator` class to accept and use the provided session ID
- Updated session path generation to use custom session ID when provided
- Added comprehensive documentation in `README.md` and `CHANGELOG.md`

### Benefits

- **Predictable session identifiers**: Users can now specify meaningful session IDs for better organization
- **External system integration**: Enables integration with external systems that need to reference specific sessions
- **Backward compatibility**: Maintains existing behavior when no session ID is provided (auto-generates UUID)

### Usage

```bash
# Use a custom session ID
claude-swarm start --session-id my-custom-session-123

# Still works with auto-generated UUID if not specified
claude-swarm start
```

🤖 Generated with [Claude Code](https://claude.ai/code)