### PR TITLE
feat: add environment variable default values support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
   - Variables are interpolated recursively in strings, arrays, and nested structures
   - Fails with clear error message if referenced environment variable is not set
   - Supports multiple variables in the same string and partial string interpolation
+- **Environment variable defaults**: Environment variables in configuration now support default values
+  - Use `${ENV_VAR_NAME:=default_value}` syntax to provide defaults
+  - Default values are used when the environment variable is not set
+  - Supports any string as default value, including spaces and special characters
+  - Examples: `${DB_PORT:=5432}`, `${API_URL:=https://api.example.com}`
 - **Session path display in show command**: The `claude-swarm show SESSION_ID` command now displays the session path for easier access to session files
 - **Main process PID tracking**: The orchestrator now writes its process ID to `SESSION_PATH/main_pid` for external monitoring and management
 - **Swarm execution summary**: Display runtime duration and total cost at the end of each swarm run [@claudenm]

--- a/README.md
+++ b/README.md
@@ -256,6 +256,32 @@ Features:
 - If a referenced environment variable is not set, Claude Swarm will exit with a clear error message
 - Non-matching patterns like `$VAR` or `{VAR}` are preserved as-is
 
+##### Default Values
+
+Environment variables can have default values using the `${VAR_NAME:=default_value}` syntax:
+
+```yaml
+version: 1
+swarm:
+  name: "Dev Team"
+  main: lead
+  instances:
+    lead:
+      description: "Lead developer"
+      directory: "${PROJECT_DIR:=.}"
+      model: "${CLAUDE_MODEL:=sonnet}"
+      mcps:
+        - name: api-server
+          type: sse
+          url: "${API_URL:=http://localhost:8080}"
+      worktree: "${BRANCH_NAME:=feature-branch}"
+```
+
+- Default values are used when the environment variable is not set
+- Any string can be used as a default value, including spaces and special characters
+- Empty defaults are supported: `${VAR:=}` results in an empty string if VAR is not set
+- Works in all configuration values: strings, arrays, and nested structures
+
 #### Instance Configuration
 
 Each instance must have:

--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -10,6 +10,7 @@ module ClaudeSwarm
 
     # Regex patterns
     ENV_VAR_PATTERN = /\$\{([^}]+)\}/
+    ENV_VAR_WITH_DEFAULT_PATTERN = /\$\{([^:}]+)(:=([^}]*))?\}/
     O_SERIES_MODEL_PATTERN = /^o\d+(\s+(Preview|preview))?(-pro|-mini|-deep-research|-mini-deep-research)?$/
 
     attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances
@@ -67,10 +68,15 @@ module ClaudeSwarm
     end
 
     def interpolate_env_string(str)
-      str.gsub(ENV_VAR_PATTERN) do |_match|
+      str.gsub(ENV_VAR_WITH_DEFAULT_PATTERN) do |_match|
         env_var = Regexp.last_match(1)
+        has_default = Regexp.last_match(2)
+        default_value = Regexp.last_match(3)
+
         if ENV.key?(env_var)
           ENV[env_var]
+        elsif has_default
+          default_value || ""
         else
           raise Error, "Environment variable '#{env_var}' is not set"
         end


### PR DESCRIPTION
## Summary
- Added support for environment variable default values using `${VAR_NAME:=default_value}` syntax
- Default values are used when environment variable is not set
- Works throughout all YAML configuration values

## Implementation Details
- Modified `interpolate_env_string` method to handle the `:=` syntax for defaults
- Added new regex pattern `ENV_VAR_WITH_DEFAULT_PATTERN` to match variables with optional defaults
- Maintains backward compatibility with existing `${VAR}` syntax

## Testing
- Added comprehensive test suite covering all use cases:
  - Basic default values when variable is not set
  - Variables with existing values override defaults
  - Empty defaults (`${VAR:=}`)
  - Multiple variables with defaults in same string
  - Defaults in arrays and nested structures
  - Special characters and spaces in default values
  - Mixed usage with and without defaults

## Documentation
- Updated CHANGELOG.md with new feature details
- Added documentation to README.md with examples and usage guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)