### PR TITLE
feat: enhance session metadata with instance directory tracking

### DIFF
--- a/test/helpers/test_helpers.rb
+++ b/test/helpers/test_helpers.rb
@@ -241,6 +241,38 @@ module TestHelpers
       # Just return the current session path
       ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil)
     end
+
+    def assert_valid_instance_metadata(metadata, instance_name, expected_config)
+      assert_includes(
+        metadata[:instance_configs].keys,
+        instance_name,
+        "Expected metadata to include instance '#{instance_name}'",
+      )
+
+      instance_config = metadata[:instance_configs][instance_name]
+
+      assert_equal(
+        expected_config[:worktree_config],
+        instance_config[:worktree_config],
+        "Worktree config mismatch for instance '#{instance_name}'",
+      )
+      assert_equal(
+        expected_config[:directories],
+        instance_config[:directories],
+        "Directories mismatch for instance '#{instance_name}'",
+      )
+      assert_equal(
+        expected_config[:worktree_paths],
+        instance_config[:worktree_paths],
+        "Worktree paths mismatch for instance '#{instance_name}'",
+      )
+    end
+
+    def calculate_worktree_path(repo_dir, worktree_name, session_id = "default")
+      repo_name = File.basename(repo_dir)
+      repo_hash = Digest::SHA256.hexdigest(repo_dir)[0..7]
+      File.expand_path("~/.claude-swarm/worktrees/#{session_id}/#{repo_name}-#{repo_hash}/#{worktree_name}")
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Enhanced the WorktreeManager to track both original directories and their mapped worktree paths in session metadata. This improvement provides better session restoration capabilities by maintaining a clear mapping between the original instance directories and their corresponding worktree locations.

### Key Changes

- **Enhanced WorktreeManager**: Added `instance_directories` tracking to session metadata alongside existing worktree information
- **Improved Session Restoration**: The system now tracks both original directories and their mapped worktree paths, enabling more robust session restoration
- **Better Worktree Management**: Clearer separation between original instance configuration and runtime worktree mappings

### Files Modified

- `lib/claude_swarm/worktree_manager.rb`: Enhanced to track instance directories in session metadata
- `test/helpers/test_helpers.rb`: Added helper methods for comprehensive testing
- `test/worktree_manager_test.rb`: Added 296 lines of comprehensive tests covering all scenarios

## Test Plan

- [x] All existing tests pass
- [x] New comprehensive tests added covering:
  - [x] Session metadata creation with instance directory tracking
  - [x] Worktree creation and cleanup scenarios
  - [x] Error handling for invalid configurations
  - [x] Edge cases with mixed worktree configurations
- [x] Manual testing of session restoration functionality
- [x] RuboCop linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)