### PR TITLE
feat: add ruby-openai version validation for responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.2.1]
+
+### Added
+- **Ruby-OpenAI version validation**: Added validation to ensure ruby-openai >= 8.0 when using OpenAI provider with `api_version: "responses"`
+  - The responses API requires ruby-openai version 8.0 or higher
+  - Configuration validation now checks the installed version and provides helpful error messages
+  - Gracefully handles cases where ruby-openai is not installed
+
+### Changed
+- **Relaxed ruby-openai dependency**: The gemspec now accepts ruby-openai versions 7.x and 8.x (`>= 7.0, < 9.0`)
+  - Version 7.x works with the default chat_completion API
+  - Version 8.x is required for the responses API
+
 ## [0.2.0]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    claude_swarm (0.2.0)
+    claude_swarm (0.2.1)
       fast-mcp-annotations (~> 1.5.3)
       ruby-mcp-client (~> 0.7)
-      ruby-openai (~> 8.1)
+      ruby-openai (>= 7.0, < 9.0)
       thor (~> 1.3)
       zeitwerk (~> 2.6)
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ When using `provider: openai`, the following additional fields are available:
 - GPT models support `temperature` but not `reasoning_effort`
 - OpenAI instances default to and ONLY operate as `vibe: true` and use MCP for tool access
 - By default it comes with Claude Code tools, connected with MCP to `claude mcp serve`
+- **Using the responses API requires ruby-openai >= 8.0** - the gem will validate this requirement at runtime
 
 ```yaml
 instance_name:

--- a/claude_swarm.gemspec
+++ b/claude_swarm.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("fast-mcp-annotations", "~> 1.5.3")
   spec.add_dependency("ruby-mcp-client", "~> 0.7")
-  spec.add_dependency("ruby-openai", "~> 8.1")
+  spec.add_dependency("ruby-openai", ">= 7.0", "< 9.0")
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/configuration_openai_responses_api_test.rb
+++ b/test/configuration_openai_responses_api_test.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigurationOpenaiResponsesApiTest < Minitest::Test
+  def with_openai_config_file(instances_config)
+    with_temp_dir do
+      instances_yaml = instances_config.map do |name, config|
+        lines = ["    #{name}:"]
+        config.each do |key, value|
+          # Handle array values differently
+          lines << if value.is_a?(Array)
+            "      #{key}: [#{value.join(", ")}]"
+          else
+            "      #{key}: #{value}"
+          end
+        end
+        lines.join("\n")
+      end.join("\n")
+
+      yaml_content = <<~YAML
+        version: 1
+        swarm:
+          name: "Test Swarm"
+          main: lead
+          instances:
+        #{instances_yaml}
+      YAML
+
+      write_config_file("claude-swarm.yml", yaml_content)
+      yield "claude-swarm.yml"
+    end
+  end
+
+  def with_stubbed_openai_version(version)
+    # Store original VERSION if OpenAI is loaded
+    original_version = ::OpenAI::VERSION if Object.const_defined?(:OpenAI) && ::OpenAI.const_defined?(:VERSION)
+
+    # Ensure OpenAI module exists
+    unless Object.const_defined?(:OpenAI)
+      Object.const_set(:OpenAI, Module.new)
+    end
+
+    # Set the version
+    ::OpenAI.send(:remove_const, :VERSION) if ::OpenAI.const_defined?(:VERSION)
+    ::OpenAI.const_set(:VERSION, version)
+
+    yield
+  ensure
+    # Restore original state
+    if original_version
+      ::OpenAI.send(:remove_const, :VERSION) if ::OpenAI.const_defined?(:VERSION)
+      ::OpenAI.const_set(:VERSION, original_version)
+    elsif Object.const_defined?(:OpenAI) && !defined?(original_version)
+      Object.send(:remove_const, :OpenAI)
+    end
+  end
+
+  def test_validates_openai_responses_api_requires_version_8_or_higher
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "backend" => {
+        "description" => "Backend with responses API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "responses",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      # Test with old version - should raise error
+      with_stubbed_openai_version("7.5.0") do
+        error = assert_error_message(ClaudeSwarm::Error, /requires ruby-openai >= 8.0/) do
+          ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+        end
+        assert_match(/Instances backend use OpenAI provider/, error.message)
+        assert_match(/Current version is 7.5.0/, error.message)
+      end
+
+      # Test with exact version 8.0.0 - should pass
+      with_stubbed_openai_version("8.0.0") do
+        config = ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+
+        assert_equal("Test Swarm", config.swarm_name)
+      end
+
+      # Test with higher version - should pass
+      with_stubbed_openai_version("8.5.0") do
+        config = ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+
+        assert_equal("Test Swarm", config.swarm_name)
+      end
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_multiple_instances_with_responses_api_lists_all_in_error
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "frontend" => {
+        "description" => "Frontend with responses API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "responses",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+      "backend" => {
+        "description" => "Backend with responses API",
+        "provider" => "openai",
+        "model" => "gpt-3.5-turbo",
+        "api_version" => "responses",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+      "database" => {
+        "description" => "Database with chat API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "chat_completion",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      with_stubbed_openai_version("6.0.0") do
+        error = assert_error_message(ClaudeSwarm::Error, /requires ruby-openai >= 8.0/) do
+          ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+        end
+        # Should list both frontend and backend, but not database
+        assert_match(/Instances frontend, backend use OpenAI provider/, error.message)
+        assert_match(/Current version is 6.0.0/, error.message)
+      end
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_chat_completion_api_does_not_require_version_check
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "backend" => {
+        "description" => "Backend with chat API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "chat_completion",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      # Should pass even with old version since it's using chat_completion
+      with_stubbed_openai_version("6.0.0") do
+        config = ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+
+        assert_equal("Test Swarm", config.swarm_name)
+        assert_equal("chat_completion", config.instances["backend"][:api_version])
+      end
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_default_api_version_is_chat_completion
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "backend" => {
+        "description" => "Backend without explicit API version",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      # Should default to chat_completion and not require version check
+      with_stubbed_openai_version("6.0.0") do
+        config = ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+
+        assert_equal("Test Swarm", config.swarm_name)
+        assert_equal("chat_completion", config.instances["backend"][:api_version])
+      end
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_claude_instances_are_not_affected_by_openai_validation
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "claude_backend" => {
+        "description" => "Claude backend",
+        "provider" => "claude",
+        "model" => "opus",
+      },
+      "openai_backend" => {
+        "description" => "OpenAI backend with responses API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "responses",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      with_stubbed_openai_version("7.0.0") do
+        error = assert_error_message(ClaudeSwarm::Error, /requires ruby-openai >= 8.0/) do
+          ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+        end
+        # Should only mention the OpenAI instance
+        assert_match(/Instances openai_backend use OpenAI provider/, error.message)
+        refute_match(/claude_backend/, error.message)
+      end
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_handles_missing_openai_gem_gracefully
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+        "prompt" => "Test prompt",
+      },
+      "backend" => {
+        "description" => "Backend with responses API",
+        "provider" => "openai",
+        "model" => "gpt-4",
+        "api_version" => "responses",
+        "openai_token_env" => "TEST_OPENAI_KEY",
+      },
+    }
+
+    ENV["TEST_OPENAI_KEY"] = "test-key"
+
+    with_openai_config_file(instances) do |config_path|
+      # Store original state
+      openai_was_defined = Object.const_defined?(:OpenAI)
+      openai_module = ::OpenAI if openai_was_defined
+
+      # Create a custom configuration that mocks the LoadError
+      config_instance = nil
+
+      # Temporarily stub require to raise LoadError
+      Kernel.stub(:require, ->(lib) do
+        if lib == "openai/version"
+          # Remove OpenAI constant when require is called
+          Object.send(:remove_const, :OpenAI) if Object.const_defined?(:OpenAI)
+          raise LoadError, "cannot load such file -- #{lib}"
+        end
+        true
+      end) do
+        # Should not raise error when ruby-openai is not installed
+        config_instance = ClaudeSwarm::Configuration.new(config_path, options: { prompt: "test" })
+      end
+
+      assert_equal("Test Swarm", config_instance.swarm_name)
+
+      # Restore OpenAI if it was originally defined
+      Object.const_set(:OpenAI, openai_module) if openai_was_defined && !Object.const_defined?(:OpenAI)
+    end
+  ensure
+    ENV.delete("TEST_OPENAI_KEY")
+  end
+
+  def test_no_openai_instances_skips_validation
+    instances = {
+      "lead" => {
+        "description" => "Lead instance",
+      },
+      "backend" => {
+        "description" => "Backend instance",
+        "provider" => "claude",
+        "model" => "opus",
+      },
+    }
+
+    with_openai_config_file(instances) do |config_path|
+      # Should not even check OpenAI version when no OpenAI instances
+      config = ClaudeSwarm::Configuration.new(config_path)
+
+      assert_equal("Test Swarm", config.swarm_name)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add validation to ensure ruby-openai >= 8.0 when using OpenAI provider with `api_version: "responses"`
- Update documentation to clarify version requirements
- Add comprehensive test coverage

## Details
This PR adds a new validation in the configuration parser that checks the installed ruby-openai version when any instance uses the OpenAI provider with the responses API. The responses API was introduced in ruby-openai 8.0, so we need to ensure users have the correct version installed.

### Changes:
1. **New validation method**: `validate_openai_responses_api_compatibility` in `ClaudeSwarm::Configuration`
2. **Updated CHANGELOG.md**: Added version 0.2.1 entry documenting this change
3. **Updated README.md**: Added note about version requirement in the OpenAI Provider Configuration section
4. **Comprehensive tests**: Added tests covering all scenarios including version checking and error handling

### Why this matters:
- The gemspec was recently relaxed to accept ruby-openai >= 7.0
- However, the responses API only works with version 8.0+
- This validation provides a clear error message to users who try to use the responses API with an older version

## Test plan
- [x] All existing tests pass
- [x] New tests added for the validation logic
- [x] Tested with various version scenarios
- [x] RuboCop linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)