### PR TITLE
feat: add --root-dir parameter to enable running from anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.3.0]
 
 ### Added
 - **Root directory parameter**: Added `--root-dir` option to the `start` command to enable running claude-swarm from any directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [Unreleased]
+
+### Added
+- **Root directory parameter**: Added `--root-dir` option to the `start` command to enable running claude-swarm from any directory
+  - Use `claude-swarm start /path/to/config.yml --root-dir /path/to/project` to run from anywhere
+  - All relative paths in configuration files are resolved from the root directory
+  - Defaults to current directory when not specified, maintaining backward compatibility
+  - Environment variable `CLAUDE_SWARM_ROOT_DIR` is set and inherited by all child processes
+
+### Changed
+- **BREAKING CHANGE: Renamed session directory references**: Session metadata and file storage have been updated to use "root_directory" terminology
+  - Environment variable renamed from `CLAUDE_SWARM_START_DIR` to `CLAUDE_SWARM_ROOT_DIR`
+  - Session file renamed from `start_directory` to `root_directory`
+  - Session metadata field renamed from `"start_directory"` to `"root_directory"`
+  - Display text in `show` command changed from "Start Directory:" to "Root Directory:"
+- **Refactored root directory access**: Introduced `ClaudeSwarm.root_dir` method for cleaner code
+  - Centralizes root directory resolution logic
+  - Replaces repetitive `ENV.fetch` calls throughout the codebase
+
 ## [0.2.1]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_swarm (0.2.1)
+    claude_swarm (0.3.0)
       fast-mcp-annotations (~> 1.5.3)
       ruby-mcp-client (~> 0.7)
       ruby-openai (>= 7.0, < 9.0)

--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -37,4 +37,10 @@ loader.setup
 
 module ClaudeSwarm
   class Error < StandardError; end
+
+  class << self
+    def root_dir
+      ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+    end
+  end
 end

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -57,7 +57,7 @@ module ClaudeSwarm
       end
 
       begin
-        config = Configuration.new(config_path, base_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd), options: options)
+        config = Configuration.new(config_path, base_dir: ClaudeSwarm.root_dir, options: options)
         generator = McpGenerator.new(config, vibe: options[:vibe])
         orchestrator = Orchestrator.new(
           config,
@@ -542,7 +542,7 @@ module ClaudeSwarm
           ENV["CLAUDE_SWARM_ROOT_DIR"] = Dir.pwd
         end
 
-        config = Configuration.new(config_file, base_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd))
+        config = Configuration.new(config_file, base_dir: ClaudeSwarm.root_dir)
 
         # Load session metadata if it exists to check for worktree info
         session_metadata_file = File.join(session_path, "session_metadata.json")

--- a/lib/claude_swarm/commands/ps.rb
+++ b/lib/claude_swarm/commands/ps.rb
@@ -82,10 +82,10 @@ module ClaudeSwarm
         swarm_name = config.dig("swarm", "name") || "Unknown"
         main_instance = config.dig("swarm", "main")
 
-        # Get base directory from session metadata or start_directory file
-        base_dir = Dir.pwd
-        start_dir_file = File.join(session_dir, "start_directory")
-        base_dir = File.read(start_dir_file).strip if File.exist?(start_dir_file)
+        # Get base directory from session metadata or root_directory file
+        base_dir = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+        root_dir_file = File.join(session_dir, "root_directory")
+        base_dir = File.read(root_dir_file).strip if File.exist?(root_dir_file)
 
         # Get all directories - handle both string and array formats
         dir_config = config.dig("swarm", "instances", main_instance, "directory")

--- a/lib/claude_swarm/commands/ps.rb
+++ b/lib/claude_swarm/commands/ps.rb
@@ -83,7 +83,7 @@ module ClaudeSwarm
         main_instance = config.dig("swarm", "main")
 
         # Get base directory from session metadata or root_directory file
-        base_dir = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+        base_dir = ClaudeSwarm.root_dir
         root_dir_file = File.join(session_dir, "root_directory")
         base_dir = File.read(root_dir_file).strip if File.exist?(root_dir_file)
 

--- a/lib/claude_swarm/commands/show.rb
+++ b/lib/claude_swarm/commands/show.rb
@@ -37,9 +37,9 @@ module ClaudeSwarm
 
         puts "Total Cost: #{cost_display}"
 
-        # Try to read start directory
-        start_dir_file = File.join(session_path, "start_directory")
-        puts "Start Directory: #{File.read(start_dir_file).strip}" if File.exist?(start_dir_file)
+        # Try to read root directory
+        root_dir_file = File.join(session_path, "root_directory")
+        puts "Root Directory: #{File.read(root_dir_file).strip}" if File.exist?(root_dir_file)
 
         puts
         puts "Instance Hierarchy:"

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -44,7 +44,7 @@ module ClaudeSwarm
         session_path = @restore_session_path
         @session_path = session_path
         ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
-        ENV["CLAUDE_SWARM_START_DIR"] = Dir.pwd
+        ENV["CLAUDE_SWARM_ROOT_DIR"] = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
 
         # Create run symlink for restored session
         create_run_symlink
@@ -78,9 +78,9 @@ module ClaudeSwarm
 
         # Generate and set session path for all instances
         session_path = if @provided_session_id
-          SessionPath.generate(working_dir: Dir.pwd, session_id: @provided_session_id)
+          SessionPath.generate(working_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd), session_id: @provided_session_id)
         else
-          SessionPath.generate(working_dir: Dir.pwd)
+          SessionPath.generate(working_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd))
         end
         SessionPath.ensure_directory(session_path)
         @session_path = session_path
@@ -89,7 +89,7 @@ module ClaudeSwarm
         @session_id = File.basename(session_path)
 
         ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
-        ENV["CLAUDE_SWARM_START_DIR"] = Dir.pwd
+        ENV["CLAUDE_SWARM_ROOT_DIR"] = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
 
         # Create run symlink for new session
         create_run_symlink
@@ -345,13 +345,13 @@ module ClaudeSwarm
       config_copy_path = File.join(session_path, "config.yml")
       FileUtils.cp(@config.config_path, config_copy_path)
 
-      # Save the original working directory
-      start_dir_file = File.join(session_path, "start_directory")
-      File.write(start_dir_file, Dir.pwd)
+      # Save the root directory
+      root_dir_file = File.join(session_path, "root_directory")
+      File.write(root_dir_file, ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd))
 
       # Save session metadata
       metadata = {
-        "start_directory" => Dir.pwd,
+        "root_directory" => ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd),
         "timestamp" => Time.now.utc.iso8601,
         "start_time" => @start_time.utc.iso8601,
         "swarm_name" => @config.swarm_name,

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -44,7 +44,7 @@ module ClaudeSwarm
         session_path = @restore_session_path
         @session_path = session_path
         ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
-        ENV["CLAUDE_SWARM_ROOT_DIR"] = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+        ENV["CLAUDE_SWARM_ROOT_DIR"] = ClaudeSwarm.root_dir
 
         # Create run symlink for restored session
         create_run_symlink
@@ -78,9 +78,9 @@ module ClaudeSwarm
 
         # Generate and set session path for all instances
         session_path = if @provided_session_id
-          SessionPath.generate(working_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd), session_id: @provided_session_id)
+          SessionPath.generate(working_dir: ClaudeSwarm.root_dir, session_id: @provided_session_id)
         else
-          SessionPath.generate(working_dir: ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd))
+          SessionPath.generate(working_dir: ClaudeSwarm.root_dir)
         end
         SessionPath.ensure_directory(session_path)
         @session_path = session_path
@@ -89,7 +89,7 @@ module ClaudeSwarm
         @session_id = File.basename(session_path)
 
         ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
-        ENV["CLAUDE_SWARM_ROOT_DIR"] = ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+        ENV["CLAUDE_SWARM_ROOT_DIR"] = ClaudeSwarm.root_dir
 
         # Create run symlink for new session
         create_run_symlink
@@ -347,11 +347,11 @@ module ClaudeSwarm
 
       # Save the root directory
       root_dir_file = File.join(session_path, "root_directory")
-      File.write(root_dir_file, ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd))
+      File.write(root_dir_file, ClaudeSwarm.root_dir)
 
       # Save session metadata
       metadata = {
-        "root_directory" => ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd),
+        "root_directory" => ClaudeSwarm.root_dir,
         "timestamp" => Time.now.utc.iso8601,
         "start_time" => @start_time.utc.iso8601,
         "swarm_name" => @config.swarm_name,

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end

--- a/test/commands/ps_test.rb
+++ b/test/commands/ps_test.rb
@@ -193,8 +193,8 @@ module ClaudeSwarm
 
       def test_execute_with_expanded_paths
         # Create a session with relative directory
-        start_dir = "/Users/test/projects/myapp"
-        File.write(File.join(@test_session_dir, "start_directory"), start_dir)
+        root_dir = "/Users/test/projects/myapp"
+        File.write(File.join(@test_session_dir, "root_directory"), root_dir)
 
         config = {
           "swarm" => {
@@ -214,14 +214,14 @@ module ClaudeSwarm
         output = capture_io { Commands::Ps.new.execute }.first
 
         # Should show expanded path, not "."
-        assert_match(start_dir, output)
+        assert_match(root_dir, output)
         refute_match(/DIRECTORY\s+\.$/, output)
       end
 
       def test_execute_with_worktree_paths
         # Create a session with worktree metadata
-        start_dir = "/Users/test/projects/myapp"
-        File.write(File.join(@test_session_dir, "start_directory"), start_dir)
+        root_dir = "/Users/test/projects/myapp"
+        File.write(File.join(@test_session_dir, "root_directory"), root_dir)
 
         config = {
           "swarm" => {
@@ -243,7 +243,7 @@ module ClaudeSwarm
             "enabled" => true,
             "shared_name" => "feature-branch",
             "created_paths" => {
-              "#{start_dir}:feature-branch" => "#{start_dir}/.worktrees/feature-branch",
+              "#{root_dir}:feature-branch" => "#{root_dir}/.worktrees/feature-branch",
             },
           },
         }
@@ -253,19 +253,19 @@ module ClaudeSwarm
 
         # Mock find_git_root to return the start_dir as if it's a git repo
         ps_instance = Commands::Ps.new
-        ps_instance.stub(:find_git_root, start_dir) do
+        ps_instance.stub(:find_git_root, root_dir) do
           output = capture_io { ps_instance.execute }.first
 
           # Should show worktree path
-          assert_match("#{start_dir}/.worktrees/feature-branch", output)
-          refute_match(/DIRECTORY\s+#{Regexp.escape(start_dir)}$/, output)
+          assert_match("#{root_dir}/.worktrees/feature-branch", output)
+          refute_match(/DIRECTORY\s+#{Regexp.escape(root_dir)}$/, output)
         end
       end
 
       def test_execute_with_multiple_worktree_paths
         # Create a session with multiple directories and worktrees
-        start_dir = "/Users/test/projects"
-        File.write(File.join(@test_session_dir, "start_directory"), start_dir)
+        root_dir = "/Users/test/projects"
+        File.write(File.join(@test_session_dir, "root_directory"), root_dir)
 
         config = {
           "swarm" => {
@@ -287,8 +287,8 @@ module ClaudeSwarm
             "enabled" => true,
             "shared_name" => "feature-x",
             "created_paths" => {
-              "#{start_dir}/app1:feature-x" => "#{start_dir}/app1/.worktrees/feature-x",
-              "#{start_dir}/app2:feature-x" => "#{start_dir}/app2/.worktrees/feature-x",
+              "#{root_dir}/app1:feature-x" => "#{root_dir}/app1/.worktrees/feature-x",
+              "#{root_dir}/app2:feature-x" => "#{root_dir}/app2/.worktrees/feature-x",
             },
           },
         }
@@ -310,13 +310,13 @@ module ClaudeSwarm
         output = capture_io { ps_instance.execute }.first
 
         # Should show both worktree paths
-        assert_match("#{start_dir}/app1/.worktrees/feature-x, #{start_dir}/app2/.worktrees/feature-x", output)
+        assert_match("#{root_dir}/app1/.worktrees/feature-x, #{root_dir}/app2/.worktrees/feature-x", output)
       end
 
       def test_execute_without_worktree_metadata
         # Test that sessions without worktree metadata still work
-        start_dir = "/Users/test/projects/myapp"
-        File.write(File.join(@test_session_dir, "start_directory"), start_dir)
+        root_dir = "/Users/test/projects/myapp"
+        File.write(File.join(@test_session_dir, "root_directory"), root_dir)
 
         config = {
           "swarm" => {
@@ -339,7 +339,7 @@ module ClaudeSwarm
         output = capture_io { Commands::Ps.new.execute }.first
 
         # Should show expanded path without worktree
-        assert_match("#{start_dir}/src", output)
+        assert_match("#{root_dir}/src", output)
       end
     end
   end

--- a/test/commands/show_test.rb
+++ b/test/commands/show_test.rb
@@ -89,13 +89,13 @@ module ClaudeSwarm
         assert_match(/Total Cost: \$0\.5000$/, output)
       end
 
-      def test_execute_with_start_directory
+      def test_execute_with_root_directory
         setup_test_session_with_hierarchy
-        File.write(File.join(@test_session_dir, "start_directory"), "/home/user/project")
+        File.write(File.join(@test_session_dir, "root_directory"), "/home/user/project")
 
         output = capture_io { Commands::Show.new.execute("test-session-123") }.first
 
-        assert_match(%r{Start Directory: /home/user/project}, output)
+        assert_match(%r{Root Directory: /home/user/project}, output)
       end
 
       def test_find_session_in_all_sessions

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -1127,6 +1127,9 @@ class OrchestratorTest < Minitest::Test
   end
 
   def test_session_id_saved_in_metadata
+    # Set root directory for test
+    ENV["CLAUDE_SWARM_ROOT_DIR"] = Dir.pwd
+
     config = create_test_config
     generator = ClaudeSwarm::McpGenerator.new(config)
     custom_session_id = "metadata-test-456"
@@ -1150,7 +1153,7 @@ class OrchestratorTest < Minitest::Test
 
     metadata = JSON.parse(File.read(metadata_file))
 
-    assert_equal(Dir.pwd, metadata["start_directory"])
+    assert_equal(Dir.pwd, metadata["root_directory"])
     assert_equal("Test Swarm", metadata["swarm_name"])
   end
 end

--- a/test/orchestrator_worktree_restoration_test.rb
+++ b/test/orchestrator_worktree_restoration_test.rb
@@ -41,7 +41,7 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
 
     # Simulate saving worktree metadata with external path
     metadata = {
-      "start_directory" => @repo_dir,
+      "root_directory" => @repo_dir,
       "timestamp" => Time.now.utc.iso8601,
       "swarm_name" => "Test Swarm",
       "claude_swarm_version" => "0.1.0",
@@ -139,7 +139,7 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
   def test_restoration_without_worktrees
     # Simulate saving metadata without worktrees
     metadata = {
-      "start_directory" => @repo_dir,
+      "root_directory" => @repo_dir,
       "timestamp" => Time.now.utc.iso8601,
       "swarm_name" => "Test Swarm",
       "claude_swarm_version" => "0.1.0",

--- a/test/working_directory_restoration_test.rb
+++ b/test/working_directory_restoration_test.rb
@@ -37,7 +37,7 @@ class WorkingDirectoryRestorationTest < Minitest::Test
     FileUtils.cp(@config_path, File.join(@session_dir, "config.yml"))
 
     # Save the original working directory
-    File.write(File.join(@session_dir, "start_directory"), @project_dir)
+    File.write(File.join(@session_dir, "root_directory"), @project_dir)
   end
 
   def teardown
@@ -94,7 +94,7 @@ class WorkingDirectoryRestorationTest < Minitest::Test
     begin
       Dir.chdir(other_dir) do
         # This simulates what happens in CLI#restore_session
-        original_dir = File.read(File.join(@session_dir, "start_directory")).strip
+        original_dir = File.read(File.join(@session_dir, "root_directory")).strip
 
         # Change to original directory
         Dir.chdir(original_dir) do


### PR DESCRIPTION
## Summary
- Added `--root-dir` parameter to the `start` command to enable running claude-swarm from any directory
- Refactored root directory handling with a centralized `ClaudeSwarm.root_dir` method
- Updated all session metadata references from "start_directory" to "root_directory" for clarity

## Breaking Changes
- Environment variable renamed from `CLAUDE_SWARM_START_DIR` to `CLAUDE_SWARM_ROOT_DIR`
- Session file renamed from `start_directory` to `root_directory`
- Session metadata field renamed from `"start_directory"` to `"root_directory"`
- Display text in `show` command changed from "Start Directory:" to "Root Directory:"

## Usage
Users can now run claude-swarm from anywhere:
```bash
# Run from any directory
claude-swarm start /path/to/project/claude-swarm.yml --root-dir /path/to/project

# Or from the project directory (backward compatible)
cd /path/to/project
claude-swarm start  # root_dir defaults to current directory
```

All relative paths in configuration files are resolved from the specified root directory.

## Implementation Details
1. Added `--root-dir` option to CLI start command
2. Set `ENV["CLAUDE_SWARM_ROOT_DIR"]` early in execution for all components
3. Created `ClaudeSwarm.root_dir` method for cleaner access throughout codebase
4. Updated all tests to use new naming conventions
5. All tests pass and code is clean according to RuboCop

🤖 Generated with [Claude Code](https://claude.ai/code)