### PR TITLE
Add support for thinking_budget parameter

### DIFF
--- a/lib/claude_swarm/claude_mcp_server.rb
+++ b/lib/claude_swarm/claude_mcp_server.rb
@@ -63,10 +63,11 @@ module ClaudeSwarm
       )
 
       # Set dynamic description for TaskTool based on instance config
+      thinking_info = " Thinking budget levels: \"think\" < \"think hard\" < \"think harder\" < \"ultrathink\"."
       if @instance_config[:description]
-        Tools::TaskTool.description("Execute a task using Agent #{@instance_config[:name]}. #{@instance_config[:description]}")
+        Tools::TaskTool.description("Execute a task using Agent #{@instance_config[:name]}. #{@instance_config[:description]} #{thinking_info}")
       else
-        Tools::TaskTool.description("Execute a task using Agent #{@instance_config[:name]}")
+        Tools::TaskTool.description("Execute a task using Agent #{@instance_config[:name]}. #{thinking_info}")
       end
 
       # Register tool classes (not instances)

--- a/lib/claude_swarm/tools/task_tool.rb
+++ b/lib/claude_swarm/tools/task_tool.rb
@@ -12,11 +12,19 @@ module ClaudeSwarm
         optional(:new_session).filled(:bool).description("Start a new session (default: false)")
         optional(:system_prompt).filled(:string).description("Override the system prompt for this request")
         optional(:description).filled(:string).description("A description for the request")
+        optional(:thinking_budget).filled(:string).description("Thinking budget: \"think\" < \"think hard\" < \"think harder\" < \"ultrathink\". Each level increases Claude's thinking allocation. Auto-select based on task complexity.")
       end
 
-      def call(prompt:, new_session: false, system_prompt: nil, description: nil)
+      def call(prompt:, new_session: false, system_prompt: nil, description: nil, thinking_budget: nil)
         executor = ClaudeMcpServer.executor
         instance_config = ClaudeMcpServer.instance_config
+
+        # Prepend thinking budget to prompt if provided
+        final_prompt = if thinking_budget
+                         "#{thinking_budget}: #{prompt}"
+                       else
+                         prompt
+                       end
 
         options = {
           new_session: new_session,
@@ -33,7 +41,7 @@ module ClaudeSwarm
         # Add connections from instance config
         options[:connections] = instance_config[:connections] if instance_config[:connections]&.any?
 
-        response = executor.execute(prompt, options)
+        response = executor.execute(final_prompt, options)
 
         # Return just the result text as expected by MCP
         response["result"]


### PR DESCRIPTION
Claude code allows controlling the thinking budget by using keywords "think", "think hard", "think harder" and "ultrathink". 

This PR exposes this as a primary feature for claude-swarm, as an optional parameter that can be provided when a task is assigned. The orchestrator / caller can then be told to use these using a prompt such as e.g.

```
        ALWAYS set an appropriate thinking_budget parameter in your delegations based on task complexity:
        - Simple bugs or straightforward tasks: Use lower thinking budget
        - Medium complexity logic or implementation: Use moderate thinking budget
        - Complex design challenges or critical analysis: Use higher thinking budget

        The thinking_budget should reflect the cognitive effort needed for the task
```

I've verified this to be working correctly as expected.