### PR TITLE
Fix bundler environment conflicts in Claude instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - MCP servers now receive necessary Ruby/Bundler environment variables to run properly
   - Claude instances (main and connected) run in clean environments via `Bundler.with_unbundled_env`
   - Prevents `bundle install` and other bundler commands from using Claude Swarm's Gemfile instead of the project's Gemfile
+  - `claude mcp serve` now runs with a filtered environment that excludes Ruby/Bundler variables while preserving system variables
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Fixed
 - **Development documentation**: Fixed `bundle exec` prefix in CLAUDE.md for development commands
+- **Bundler environment conflicts**: Fixed issue where Claude instances would inherit bundler environment variables, causing conflicts when working in Ruby projects
+  - MCP servers now receive necessary Ruby/Bundler environment variables to run properly
+  - Claude instances (main and connected) run in clean environments via `Bundler.with_unbundled_env`
+  - Prevents `bundle install` and other bundler commands from using Claude Swarm's Gemfile instead of the project's Gemfile
 
 ## [0.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [Unreleased]
+
+### Added
+- **Interactive mode with initial prompt**: Added `-i/--interactive` flag to provide an initial prompt for interactive mode
+  - Use `claude-swarm -i "Your initial prompt"` to start in interactive mode with a prompt
+  - Cannot be used together with `-p/--prompt` (which is for non-interactive mode)
+  - Allows users to provide context or initial instructions while maintaining interactive session
+
+### Fixed
+- **Development documentation**: Fixed `bundle exec` prefix in CLAUDE.md for development commands
+
 ## [0.3.0]
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,9 @@ Claude Swarm is a Ruby gem that orchestrates multiple Claude Code instances as a
 
 ## Development Commands
 
-### Setup
-```bash
-bin/setup              # Install dependencies
-```
-
 ### Testing
 ```bash
-rake test             # Run the Minitest test suite
+bundle exec rake test             # Run the Minitest test suite
 ```
 
 **Important**: Tests should not generate any output to stdout or stderr. When writing tests:
@@ -37,7 +32,7 @@ end
 
 ### Linting
 ```bash
-rake rubocop -A       # Run RuboCop linter to auto fix problems
+bundle exec rubocop -A       # Run RuboCop linter to auto fix problems
 ```
 
 ### Development Console

--- a/README.md
+++ b/README.md
@@ -767,6 +767,10 @@ claude-swarm --vibe
 claude-swarm -p "Implement the new user authentication feature"
 claude-swarm --prompt "Fix the bug in the payment module"
 
+# Run in interactive mode with an initial prompt
+claude-swarm -i "Review the codebase and suggest improvements"
+claude-swarm --interactive "Help me debug this test failure"
+
 # Use a custom session ID instead of auto-generated UUID
 claude-swarm --session-id my-custom-session-123
 

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -18,6 +18,10 @@ module ClaudeSwarm
       aliases: "-p",
       type: :string,
       desc: "Prompt to pass to the main Claude instance (non-interactive mode)"
+    method_option :interactive,
+      aliases: "-i",
+      type: :string,
+      desc: "Initial prompt for interactive mode"
     method_option :stream_logs,
       type: :boolean,
       default: false,
@@ -56,6 +60,12 @@ module ClaudeSwarm
         exit(1)
       end
 
+      # Validate conflicting options
+      if options[:prompt] && options[:interactive]
+        error("Cannot use both -p/--prompt and -i/--interactive")
+        exit(1)
+      end
+
       begin
         config = Configuration.new(config_path, base_dir: ClaudeSwarm.root_dir, options: options)
         generator = McpGenerator.new(config, vibe: options[:vibe])
@@ -64,6 +74,7 @@ module ClaudeSwarm
           generator,
           vibe: options[:vibe],
           prompt: options[:prompt],
+          interactive_prompt: options[:interactive],
           stream_logs: options[:stream_logs],
           debug: options[:debug],
           worktree: options[:worktree],

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -161,11 +161,45 @@ module ClaudeSwarm
         args.push("--claude-session-id", claude_session_id) if claude_session_id
       end
 
-      {
+      # Capture environment variables needed for Ruby and Bundler to work properly
+      # This includes both BUNDLE_* variables and Ruby-specific variables
+      required_env = {}
+
+      # Bundle-specific variables
+      ENV.each do |k, v|
+        required_env[k] = v if k.start_with?("BUNDLE_")
+      end
+
+      # Claude Swarm-specific variables
+      ENV.each do |k, v|
+        required_env[k] = v if k.start_with?("CLAUDE_SWARM_")
+      end
+
+      # Ruby-specific variables that MCP servers need
+      [
+        "RUBY_ROOT",
+        "RUBY_ENGINE",
+        "RUBY_VERSION",
+        "GEM_ROOT",
+        "GEM_HOME",
+        "GEM_PATH",
+        "RUBYOPT",
+        "RUBYLIB",
+        "PATH",
+      ].each do |key|
+        required_env[key] = ENV[key] if ENV[key]
+      end
+
+      config = {
         "type" => "stdio",
         "command" => exe_path,
         "args" => args,
       }
+
+      # Add required environment variables if any exist
+      config["env"] = required_env unless required_env.empty?
+
+      config
     end
 
     def load_instance_states

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -95,10 +95,21 @@ module ClaudeSwarm
     end
 
     def build_claude_tools_mcp_config
+      # Build environment for claude mcp serve by excluding Ruby/Bundler-specific variables
+      # This preserves all system variables while removing Ruby contamination
+      clean_env = ENV.to_h.reject do |key, _|
+        key.start_with?("BUNDLE_") ||
+          key.start_with?("RUBY") ||
+          key.start_with?("GEM_") ||
+          key == "RUBYOPT" ||
+          key == "RUBYLIB"
+      end
+
       {
         "type" => "stdio",
         "command" => "claude",
         "args" => ["mcp", "serve"],
+        "env" => clean_env,
       }
     end
 

--- a/lib/claude_swarm/openai/executor.rb
+++ b/lib/claude_swarm/openai/executor.rb
@@ -181,18 +181,23 @@ module ClaudeSwarm
           end
 
           if mcp_configs.any?
-            @mcp_client = MCPClient.create_client(
-              mcp_server_configs: mcp_configs,
-              logger: @logger,
-            )
+            # Create MCP client with unbundled environment to avoid bundler conflicts
+            # This ensures MCP servers run in a clean environment without inheriting
+            # Claude Swarm's BUNDLE_* environment variables
+            Bundler.with_unbundled_env do
+              @mcp_client = MCPClient.create_client(
+                mcp_server_configs: mcp_configs,
+                logger: @logger,
+              )
 
-            # List available tools from all MCP servers
-            begin
-              @available_tools = @mcp_client.list_tools
-              @logger.info("Loaded #{@available_tools.size} tools from #{mcp_configs.size} MCP server(s)")
-            rescue StandardError => e
-              @logger.error("Failed to load MCP tools: #{e.message}")
-              @available_tools = []
+              # List available tools from all MCP servers
+              begin
+                @available_tools = @mcp_client.list_tools
+                @logger.info("Loaded #{@available_tools.size} tools from #{mcp_configs.size} MCP server(s)")
+              rescue StandardError => e
+                @logger.error("Failed to load MCP tools: #{e.message}")
+                @available_tools = []
+              end
             end
           end
         end

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -192,7 +192,12 @@ module ClaudeSwarm
           end
         end
 
-        system!(*command)
+        # Execute main Claude instance with unbundled environment to avoid bundler conflicts
+        # This ensures the main instance runs in a clean environment without inheriting
+        # Claude Swarm's BUNDLE_* environment variables
+        Bundler.with_unbundled_env do
+          system!(*command)
+        end
       end
 
       # Clean up log streaming thread

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -295,6 +295,7 @@ class OrchestratorTest < Minitest::Test
           lead:
             description: "Test instance"
             directory: #{@tmpdir}/absolute/path
+            model: sonnet
     YAML
 
     FileUtils.mkdir_p(File.join(@tmpdir, "absolute", "path"))
@@ -315,7 +316,7 @@ class OrchestratorTest < Minitest::Test
 
     # Since we use Dir.chdir now, the path isn't part of the command
     # Just verify the command was captured
-    assert(expected_command)
+    assert(expected_command, "Expected command should not be nil")
     assert_equal("claude", expected_command[0])
   end
 
@@ -480,10 +481,11 @@ class OrchestratorTest < Minitest::Test
       end
     end
 
-    # Should add default prompt when no -p flag is provided
-    last_arg = expected_command.last
+    # Should add instance prompt via --append-system-prompt
+    append_prompt_index = expected_command.index("--append-system-prompt")
 
-    assert_match(/You are the lead developer\n\nNow just say 'I am ready to start'/, last_arg)
+    assert(append_prompt_index, "--append-system-prompt flag should be present")
+    assert_equal("You are the lead developer", expected_command[append_prompt_index + 1])
   end
 
   def test_default_prompt_for_instance_without_custom_prompt
@@ -512,10 +514,8 @@ class OrchestratorTest < Minitest::Test
       end
     end
 
-    # Should just have the generic prompt when instance has no custom prompt
-    last_arg = expected_command.last
-
-    assert_equal("\n\nNow just say 'I am ready to start'", last_arg)
+    # Should not add --append-system-prompt when instance has no custom prompt
+    refute_includes(expected_command, "--append-system-prompt")
   end
 
   def test_before_commands_feature_exists


### PR DESCRIPTION
## Summary
- Fixed issue where Claude instances would inherit bundler environment variables, causing conflicts when working in Ruby projects
- MCP servers now receive necessary Ruby/Bundler environment variables to run properly
- Claude instances run in clean environments via `Bundler.with_unbundled_env`

## Problem
When running `bundle exec claude-swarm`, Claude instances would inherit BUNDLE_* environment variables from the parent process. This caused issues when Claude instances tried to run bundler commands in Ruby project directories - they would use Claude Swarm's Gemfile instead of the project's Gemfile.

## Solution
1. **MCP servers** (`claude-swarm mcp-serve`) receive all necessary Ruby/Bundler/Claude Swarm environment variables to run properly
2. **Claude instances** (main and connected) run in clean environments using `Bundler.with_unbundled_env`
3. **`claude mcp serve`** specifically gets a filtered environment that excludes Ruby/Bundler variables while preserving system variables

## Changes
- Updated `mcp_generator.rb` to pass required environment variables to MCP server configs
- Wrapped Claude execution in `Bundler.with_unbundled_env` in:
  - `claude_code_executor.rb`
  - `orchestrator.rb` (main instance)
  - `openai/executor.rb` (MCP client creation)
- Added special handling for `claude mcp serve` to filter out Ruby/Bundler variables

## Testing
All tests pass. The implementation ensures:
- MCP servers can run with `bundle exec`
- Claude instances work cleanly in any Ruby project without bundler conflicts
- System environment variables are preserved where needed

🤖 Generated with [Claude Code](https://claude.ai/code)