### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.3.1]
 
 ### Added
 - **Interactive mode with initial prompt**: Added `-i/--interactive` flag to provide an initial prompt for interactive mode

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_swarm (0.3.0)
+    claude_swarm (0.3.1)
       fast-mcp-annotations (~> 1.5.3)
       ruby-mcp-client (~> 0.7)
       ruby-openai (>= 7.0, < 9.0)

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
## Summary
This PR bumps the version from 0.3.0 to 0.3.1 for release.

## Changes
- Updated version in `lib/claude_swarm/version.rb` from 0.3.0 to 0.3.1
- Updated CHANGELOG.md to mark version 0.3.1 as released
- Updated Gemfile.lock to reflect new version

This version bump includes the interactive mode feature and other improvements documented in the changelog.

🤖 Generated with [Claude Code](https://claude.ai/code)