### PR TITLE
Fix before/after commands environment and refactor environment handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## [0.3.3]
+
+### Fixed
+- **Before/after commands environment**: Fixed issue where before and after commands would inherit Ruby/Bundler environment variables
+  - Before and after commands now run in clean environments using the shared `ClaudeSwarm.with_clean_environment` method
+  - Prevents bundle conflicts when running setup or cleanup commands in Ruby projects
+  - Consistent with the fix applied to main instance execution in version 0.3.1
+
+### Changed
+- **Code refactoring**: Created shared environment management utilities
+  - Added `ClaudeSwarm.with_clean_environment` method for executing code in clean environments
+  - Added `ClaudeSwarm.clean_env_hash` method for generating clean environment hashes
+  - Refactored MCP generator to use the shared `clean_env_hash` method
+  - Improved code maintainability and consistency across environment handling
+
+### Added
+- **Environment tests**: Added comprehensive tests for MCP generator environment behavior
+  - Ensures claude_tools MCP correctly filters Ruby/Bundler variables
+  - Ensures instance MCP connections preserve Ruby/Bundler variables as needed
+  - Prevents regression in environment handling behavior
+
 ## [0.3.2]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_swarm (0.3.2)
+    claude_swarm (0.3.3)
       fast-mcp-annotations (~> 1.5.3)
       ruby-mcp-client (~> 0.7)
       ruby-openai (>= 7.0, < 9.0)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Swarm
 
-[![Gem Version](https://badge.fury.io/rb/claude_swarm.svg?cache_bust=0.3.0)](https://badge.fury.io/rb/claude_swarm)
+[![Gem Version](https://badge.fury.io/rb/claude_swarm.svg?cache_bust=0.3.3)](https://badge.fury.io/rb/claude_swarm)
 [![CI](https://github.com/parruda/claude-swarm/actions/workflows/ci.yml/badge.svg)](https://github.com/parruda/claude-swarm/actions/workflows/ci.yml)
 
 Claude Swarm orchestrates multiple Claude Code instances as a collaborative AI development team. It enables running AI agents with specialized roles, tools, and directory contexts, communicating via MCP (Model Context Protocol) in a tree-like hierarchy. Define your swarm topology in simple YAML and let Claude instances delegate tasks through connected instances. Perfect for complex projects requiring specialized AI agents for frontend, backend, testing, DevOps, or research tasks.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Swarm
 
-[![Gem Version](https://badge.fury.io/rb/claude_swarm.svg?cache_bust1=0.3.2)](https://badge.fury.io/rb/claude_swarm)
+[![Gem Version](https://badge.fury.io/rb/claude_swarm.svg?cache_bust=0.3.3)](https://badge.fury.io/rb/claude_swarm)
 [![CI](https://github.com/parruda/claude-swarm/actions/workflows/ci.yml/badge.svg)](https://github.com/parruda/claude-swarm/actions/workflows/ci.yml)
 
 Claude Swarm orchestrates multiple Claude Code instances as a collaborative AI development team. It enables running AI agents with specialized roles, tools, and directory contexts, communicating via MCP (Model Context Protocol) in a tree-like hierarchy. Define your swarm topology in simple YAML and let Claude instances delegate tasks through connected instances. Perfect for complex projects requiring specialized AI agents for frontend, backend, testing, DevOps, or research tasks.
@@ -42,7 +42,7 @@ gem install claude_swarm
 Or add it to your Gemfile:
 
 ```ruby
-gem 'claude_swarm', "~> 0.3.2"
+gem 'claude_swarm', "~> 0.3.3"
 ```
 
 Then run:

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -97,19 +97,11 @@ module ClaudeSwarm
     def build_claude_tools_mcp_config
       # Build environment for claude mcp serve by excluding Ruby/Bundler-specific variables
       # This preserves all system variables while removing Ruby contamination
-      clean_env = ENV.to_h.reject do |key, _|
-        key.start_with?("BUNDLE_") ||
-          key.start_with?("RUBY") ||
-          key.start_with?("GEM_") ||
-          key == "RUBYOPT" ||
-          key == "RUBYLIB"
-      end
-
       {
         "type" => "stdio",
         "command" => "claude",
         "args" => ["mcp", "serve"],
-        "env" => clean_env,
+        "env" => ClaudeSwarm.clean_env_hash,
       }
     end
 

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -192,10 +192,10 @@ module ClaudeSwarm
           end
         end
 
-        # Execute main Claude instance with unbundled environment to avoid bundler conflicts
+        # Execute main Claude instance with clean environment to avoid bundler conflicts
         # This ensures the main instance runs in a clean environment without inheriting
-        # Claude Swarm's BUNDLE_* environment variables
-        Bundler.with_unbundled_env do
+        # Claude Swarm's Ruby/Bundle environment variables
+        ClaudeSwarm.with_clean_environment do
           system!(*command)
         end
       end
@@ -250,9 +250,13 @@ module ClaudeSwarm
         begin
           puts "Debug: Executing command #{index + 1}/#{commands.size}: #{command}" if @debug && !@non_interactive_prompt
 
-          # Use system with output capture
-          output = %x(#{command} 2>&1)
-          success = $CHILD_STATUS.success?
+          # Use system with output capture in clean environment
+          output = nil
+          success = nil
+          ClaudeSwarm.with_clean_environment do
+            output = %x(#{command} 2>&1)
+            success = $CHILD_STATUS.success?
+          end
 
           # Log the output
           if @session_path
@@ -306,9 +310,13 @@ module ClaudeSwarm
         begin
           puts "Debug: Executing after command #{index + 1}/#{commands.size}: #{command}" if @debug && !@non_interactive_prompt
 
-          # Use system with output capture
-          output = %x(#{command} 2>&1)
-          success = $CHILD_STATUS.success?
+          # Use system with output capture in clean environment
+          output = nil
+          success = nil
+          ClaudeSwarm.with_clean_environment do
+            output = %x(#{command} 2>&1)
+            success = $CHILD_STATUS.success?
+          end
 
           # Log the output
           if @session_path

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end

--- a/test/claude_swarm_test.rb
+++ b/test/claude_swarm_test.rb
@@ -15,7 +15,7 @@ class ClaudeSwarmTest < Minitest::Test
     # Save original values
     original_rubyopt = ENV["RUBYOPT"]
     original_gem_home = ENV["GEM_HOME"]
-    
+
     # Set some test environment variables
     ENV["BUNDLE_TEST"] = "bundle_value"
     ENV["RUBYOPT"] = "ruby_opt_value"
@@ -32,7 +32,7 @@ class ClaudeSwarmTest < Minitest::Test
     end
 
     assert(executed, "Block should have been executed")
-    
+
     # After block, test vars should be restored (but original Ruby vars might be different)
     assert_equal("bundle_value", ENV["BUNDLE_TEST"])
   ensure

--- a/test/claude_swarm_test.rb
+++ b/test/claude_swarm_test.rb
@@ -10,4 +10,70 @@ class ClaudeSwarmTest < Minitest::Test
   def test_cli_exists
     assert_kind_of(Class, ClaudeSwarm::CLI)
   end
+
+  def test_with_clean_environment
+    # Save original values
+    original_rubyopt = ENV["RUBYOPT"]
+    original_gem_home = ENV["GEM_HOME"]
+    
+    # Set some test environment variables
+    ENV["BUNDLE_TEST"] = "bundle_value"
+    ENV["RUBYOPT"] = "ruby_opt_value"
+    ENV["GEM_HOME"] = "gem_home_value"
+
+    executed = false
+    ClaudeSwarm.with_clean_environment do
+      executed = true
+      # Bundle vars should be removed by Bundler.with_unbundled_env
+      assert_nil(ENV["BUNDLE_TEST"])
+      # Ruby vars should be removed by our additional cleaning
+      assert_nil(ENV["RUBYOPT"])
+      assert_nil(ENV["GEM_HOME"])
+    end
+
+    assert(executed, "Block should have been executed")
+    
+    # After block, test vars should be restored (but original Ruby vars might be different)
+    assert_equal("bundle_value", ENV["BUNDLE_TEST"])
+  ensure
+    # Clean up test variables
+    ENV.delete("BUNDLE_TEST")
+    # Restore original values
+    if original_rubyopt
+      ENV["RUBYOPT"] = original_rubyopt
+    else
+      ENV.delete("RUBYOPT")
+    end
+    if original_gem_home
+      ENV["GEM_HOME"] = original_gem_home
+    else
+      ENV.delete("GEM_HOME")
+    end
+  end
+
+  def test_clean_env_hash
+    # Set some test environment variables
+    ENV["BUNDLE_TEST"] = "bundle_value"
+    ENV["RUBY_VERSION"] = "ruby_version_value"
+    ENV["GEM_HOME"] = "gem_home_value"
+    ENV["RUBYOPT"] = "rubyopt_value"
+    ENV["MY_NORMAL_VAR"] = "normal_value"
+
+    clean_hash = ClaudeSwarm.clean_env_hash
+
+    # These should be removed
+    refute(clean_hash.key?("BUNDLE_TEST"))
+    refute(clean_hash.key?("RUBY_VERSION"))
+    refute(clean_hash.key?("GEM_HOME"))
+    refute(clean_hash.key?("RUBYOPT"))
+    # Normal vars should remain
+    assert_equal("normal_value", clean_hash["MY_NORMAL_VAR"])
+  ensure
+    # Clean up test variables
+    ENV.delete("BUNDLE_TEST")
+    ENV.delete("RUBY_VERSION")
+    ENV.delete("GEM_HOME")
+    ENV.delete("RUBYOPT")
+    ENV.delete("MY_NORMAL_VAR")
+  end
 end

--- a/test/mcp_generator_env_test.rb
+++ b/test/mcp_generator_env_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class McpGeneratorEnvTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @config_path = File.join(@tmpdir, "claude-swarm.yml")
+    @session_path = File.join(@tmpdir, "test_session")
+    ENV["CLAUDE_SWARM_SESSION_PATH"] = @session_path
+    
+    # Set up test environment variables
+    ENV["BUNDLE_TEST_VAR"] = "bundle_test"
+    ENV["RUBY_TEST_VAR"] = "ruby_test"
+    ENV["GEM_TEST_HOME"] = "gem_test"
+    ENV["RUBYOPT"] = "-W0"
+    ENV["NORMAL_VAR"] = "should_remain"
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+    ENV.delete("CLAUDE_SWARM_SESSION_PATH")
+    ENV.delete("BUNDLE_TEST_VAR")
+    ENV.delete("RUBY_TEST_VAR")
+    ENV.delete("GEM_TEST_HOME")
+    ENV.delete("RUBYOPT")
+    ENV.delete("NORMAL_VAR")
+  end
+
+  def test_claude_tools_mcp_config_filters_ruby_env
+    # Set up config with OpenAI provider instance to trigger claude_tools generation
+    config_yaml = <<~YAML
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Lead instance"
+            connections: [openai_instance]
+          openai_instance:
+            description: "OpenAI instance"
+            provider: openai
+            model: gpt-4
+    YAML
+    
+    File.write(@config_path, config_yaml)
+    ENV["OPENAI_API_KEY"] = "test-key"
+    
+    config = ClaudeSwarm::Configuration.new(@config_path)
+    generator = ClaudeSwarm::McpGenerator.new(config)
+    
+    Dir.chdir(@tmpdir) do
+      generator.generate_all
+      
+      # Read the generated MCP config
+      config_file = File.join(@session_path, "openai_instance.mcp.json")
+      assert(File.exist?(config_file), "MCP config file should exist")
+      
+      mcp_config = JSON.parse(File.read(config_file))
+      
+      # Check claude_tools MCP server environment
+      assert(mcp_config["mcpServers"]["claude_tools"], "Should have claude_tools server")
+      claude_tools_env = mcp_config["mcpServers"]["claude_tools"]["env"]
+      
+      # Verify Ruby/Bundle vars are filtered out
+      refute(claude_tools_env.key?("BUNDLE_TEST_VAR"), "BUNDLE vars should be filtered")
+      refute(claude_tools_env.key?("RUBY_TEST_VAR"), "RUBY vars should be filtered")
+      refute(claude_tools_env.key?("GEM_TEST_HOME"), "GEM vars should be filtered")
+      refute(claude_tools_env.key?("RUBYOPT"), "RUBYOPT should be filtered")
+      
+      # Verify normal vars remain
+      assert_equal("should_remain", claude_tools_env["NORMAL_VAR"], "Normal vars should remain")
+    end
+  ensure
+    ENV.delete("OPENAI_API_KEY")
+  end
+
+  def test_instance_mcp_config_preserves_ruby_env
+    # Set up config with connected instances
+    config_yaml = <<~YAML
+      version: 1
+      swarm:
+        name: "Test Swarm"
+        main: lead
+        instances:
+          lead:
+            description: "Lead instance"
+            connections: [worker]
+          worker:
+            description: "Worker instance"
+    YAML
+    
+    File.write(@config_path, config_yaml)
+    
+    config = ClaudeSwarm::Configuration.new(@config_path)
+    generator = ClaudeSwarm::McpGenerator.new(config)
+    
+    Dir.chdir(@tmpdir) do
+      generator.generate_all
+      
+      # Read the generated MCP config for lead instance
+      config_file = File.join(@session_path, "lead.mcp.json")
+      mcp_config = JSON.parse(File.read(config_file))
+      
+      # Check worker MCP server environment
+      worker_env = mcp_config["mcpServers"]["worker"]["env"]
+      
+      # Verify Ruby/Bundle vars are preserved for claude-swarm mcp-serve
+      assert_equal("bundle_test", worker_env["BUNDLE_TEST_VAR"], "BUNDLE vars should be preserved")
+      assert_equal("-W0", worker_env["RUBYOPT"], "RUBYOPT should be preserved")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixed issue where before/after commands inherited Ruby/Bundler environment variables causing conflicts
- Created shared environment management utilities for code consistency
- Version bumped to 0.3.3

## Problem
Before and after commands were inheriting Ruby/Bundler environment variables from Claude Swarm's execution context, which could cause conflicts when running setup or cleanup commands in Ruby projects. This was especially problematic when those commands involved bundler operations.

## Solution
Created shared environment management utilities and updated before/after command execution to use clean environments:

- **New utilities**: Added `ClaudeSwarm.with_clean_environment` method and `ClaudeSwarm.clean_env_hash` method
- **Before/after commands**: Now run in clean environments using the shared utilities
- **Code refactoring**: Refactored MCP generator to use the shared `clean_env_hash` method
- **Consistency**: All environment cleaning now uses the same approach

## What Changed
- Before and after commands now run in clean environments without Ruby/Bundler contamination
- Added comprehensive tests for environment behavior in MCP generation
- Refactored environment handling code for better maintainability
- Updated documentation in CHANGELOG

## Related
This fix is consistent with and extends the fix applied to main instance execution in PR #78. The same environment isolation principle is now applied to before/after commands for complete consistency.

## Test Plan
- All existing tests pass
- New environment-specific tests verify proper filtering behavior
- Before/after commands work correctly without bundle conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)