### PR TITLE
Fix uninitialized constant Bundler error in Orchestrator

### DIFF
--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Standard library dependencies
+require "bundler"
 require "digest"
 require "English"
 require "erb"


### PR DESCRIPTION
## Summary

- Fixes the "uninitialized constant ClaudeSwarm::Orchestrator::Bundler" error reported in issue #83
- Adds missing `require "bundler"` statement to `lib/claude_swarm.rb`
- The Orchestrator class uses `Bundler.with_unbundled_env` but bundler wasn't properly required

## Problem

Users were experiencing the following error when running claude-swarm v0.3.2:

```
Unexpected error: uninitialized constant ClaudeSwarm::Orchestrator::Bundler
```

This occurred because commit 548ab1c added usage of `Bundler.with_unbundled_env` in the Orchestrator class, but the `require "bundler"` statement was missing from the main dependency file.

## Solution

Following the project's Zeitwerk autoloading conventions, all dependencies should be required in `lib/claude_swarm.rb`. This PR adds the missing `require "bundler"` statement to ensure Bundler is available when the Orchestrator class is loaded.

## Test Plan

- [x] All existing tests pass
- [x] RuboCop linting passes
- [x] Bundler constant is now properly available throughout the application

Fixes #83

🤖 Generated with [Claude Code](https://claude.ai/code)