### PR TITLE
Update claude-code-sdk-ruby dependency to 0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+- **Updated claude-code-sdk-ruby dependency**: Bumped from 0.1.4 to 0.1.6
+  - Includes latest SDK improvements and bug fixes
+
 ## [0.3.6]
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    claude-code-sdk-ruby (0.1.4)
+    claude-code-sdk-ruby (0.1.6)
       async (~> 2)
       logger (~> 1)
     concurrent-ruby (1.3.5)


### PR DESCRIPTION
## Summary
- Updates claude-code-sdk-ruby dependency from 0.1.4 to 0.1.6
- Includes latest SDK improvements and bug fixes

## Changes
- Updated Gemfile.lock with new dependency version
- Added changelog entry documenting the update

## Test plan
- [x] Dependencies install correctly with bundle install
- [x] Existing functionality remains intact
- [x] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)