### PR TITLE
Fix: Remove unnecessary warnings and redundant file unlock in orchestrator

### DIFF
--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -573,9 +573,6 @@ module ClaudeSwarm
           pretty_json = JSON.pretty_generate(json_data)
           logger.info { pretty_json }
         rescue JSON::ParserError
-          # Warn about non-JSON output since we expect stream-json format
-          warn("⚠️  Warning: Non-JSON output detected in stream-json mode: #{line.chomp}")
-          # Log the line as-is
           logger.info { line.chomp }
         end
 
@@ -619,7 +616,6 @@ module ClaudeSwarm
                 File.open(session_json_path, File::WRONLY | File::APPEND | File::CREAT) do |log_file|
                   log_file.flock(File::LOCK_EX)
                   log_file.puts(session_entry.to_json)
-                  log_file.flock(File::LOCK_UN)
                 end
               rescue JSON::ParserError
                 # Silently skip unparseable lines


### PR DESCRIPTION
## Summary

This PR addresses issue #108 by cleaning up the orchestrator code:

### Changes Made

1. **Removed unnecessary warning messages** about non-JSON output in stream-json mode
   - These warnings were cluttering the output and not providing actionable information
   
2. **Removed redundant file unlock call** ()
   - The file lock is automatically released when the  block ends
   - This was causing unnecessary overhead and potentially confusing code

### Files Changed
- : Removed 4 lines of code (warning messages and redundant unlock)

### Testing
- [x] Changes are minimal and don't affect core functionality
- [x] File locking still works correctly (automatic unlock on block end)
- [x] No warnings or errors in logs

Fixes #108