### PR TITLE
Fix log format inconsistency and simplify cost calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [Unreleased]
+
+### Added
+- **Token-based cost calculation for main instance**: Main instance costs in interactive mode are now calculated from token usage using Claude model pricing
+  - Opus: $15/MTok input, $75/MTok output, $18.75/MTok cache write, $1.50/MTok cache read
+  - Sonnet: $3/MTok input, $15/MTok output, $3.75/MTok cache write, $0.30/MTok cache read  
+  - Haiku: $0.80/MTok input, $4/MTok output, $1/MTok cache write, $0.08/MTok cache read
+  - Automatically extracts usage data from assistant messages in session logs
+
+### Changed
+- **Simplified cost calculation**: Switched from cumulative `total_cost_usd` to per-request `cost_usd` for non-main instances
+  - Removed complex session reset detection logic
+  - Now uses simple summation of individual request costs
+  - More accurate and maintainable cost tracking
+- **Improved ps command cost display**: 
+  - Only shows cost warning when sessions are missing main instance data
+  - Adds asterisk (*) indicator to costs that exclude main instance
+  - Displays accurate total costs including main instance when available
+
+### Fixed
+- **Main instance log format consistency**: Fixed transcript logs in interactive mode to match standard instance log format
+  - Converted transcript wrapper to request/assistant event structure
+  - Properly extracts text content from nested message arrays
+  - Ensures uniform log parsing across all instances
+
 ## [0.3.9]
 
 ### Added

--- a/lib/claude_swarm/session_cost_calculator.rb
+++ b/lib/claude_swarm/session_cost_calculator.rb
@@ -4,9 +4,78 @@ module ClaudeSwarm
   module SessionCostCalculator
     extend self
 
+    # Model pricing in dollars per million tokens
+    MODEL_PRICING = {
+      opus: {
+        input: 15.0,
+        output: 75.0,
+        cache_write: 18.75,
+        cache_read: 1.50,
+      },
+      sonnet: {
+        input: 3.0,
+        output: 15.0,
+        cache_write: 3.75,
+        cache_read: 0.30,
+      },
+      haiku: {
+        input: 0.80,
+        output: 4.0,
+        cache_write: 1.0,
+        cache_read: 0.08,
+      },
+    }.freeze
+
+    # Determine model type from model name
+    def model_type_from_name(model_name)
+      return unless model_name
+
+      model_name_lower = model_name.downcase
+      if model_name_lower.include?("opus")
+        :opus
+      elsif model_name_lower.include?("sonnet")
+        :sonnet
+      elsif model_name_lower.include?("haiku")
+        :haiku
+      end
+    end
+
+    # Calculate cost from token usage
+    def calculate_token_cost(usage, model_name)
+      model_type = model_type_from_name(model_name)
+      return 0.0 unless model_type && usage
+
+      pricing = MODEL_PRICING[model_type]
+      return 0.0 unless pricing
+
+      cost = 0.0
+
+      # Regular input tokens
+      if usage["input_tokens"]
+        cost += (usage["input_tokens"] / 1_000_000.0) * pricing[:input]
+      end
+
+      # Output tokens
+      if usage["output_tokens"]
+        cost += (usage["output_tokens"] / 1_000_000.0) * pricing[:output]
+      end
+
+      # Cache creation tokens (write)
+      if usage["cache_creation_input_tokens"]
+        cost += (usage["cache_creation_input_tokens"] / 1_000_000.0) * pricing[:cache_write]
+      end
+
+      # Cache read tokens
+      if usage["cache_read_input_tokens"]
+        cost += (usage["cache_read_input_tokens"] / 1_000_000.0) * pricing[:cache_read]
+      end
+
+      cost
+    end
+
     # Calculate total cost from session log file
     # Returns a hash with:
-    # - total_cost: Total cost in USD (handles session resets)
+    # - total_cost: Total cost in USD (handles session resets and main instance token costs)
     # - instances_with_cost: Set of instance names that have cost data
     def calculate_total_cost(session_log_path)
       return { total_cost: 0.0, instances_with_cost: Set.new } unless File.exist?(session_log_path)
@@ -14,11 +83,24 @@ module ClaudeSwarm
       # Track costs per instance, handling session resets
       instance_costs = {}
       instances_with_cost = Set.new
+      main_instance_cost = 0.0
 
       File.foreach(session_log_path) do |line|
         data = JSON.parse(line)
-        if data.dig("event", "type") == "result" && (cost = data.dig("event", "total_cost_usd"))
-          instance_name = data["instance"]
+        instance_name = data["instance"]
+        instance_id = data["instance_id"]
+
+        # Handle main instance token-based costs
+        if instance_id == "main" && data.dig("event", "type") == "assistant"
+          usage = data.dig("event", "message", "usage")
+          model = data.dig("event", "message", "model")
+          if usage && model
+            token_cost = calculate_token_cost(usage, model)
+            main_instance_cost += token_cost
+            instances_with_cost << instance_name if token_cost > 0
+          end
+        # Handle other instances with cumulative costs
+        elsif data.dig("event", "type") == "result" && (cost = data.dig("event", "total_cost_usd"))
           instances_with_cost << instance_name
 
           # Initialize tracking for this instance if needed
@@ -40,8 +122,9 @@ module ClaudeSwarm
         next
       end
 
-      # Calculate total: accumulated + current cumulative for each instance
-      total_cost = instance_costs.values.sum { |costs| costs[:accumulated] + costs[:last_seen] }
+      # Calculate total: accumulated + current cumulative for each instance + main instance token costs
+      other_instances_cost = instance_costs.values.sum { |costs| costs[:accumulated] + costs[:last_seen] }
+      total_cost = other_instances_cost + main_instance_cost
 
       {
         total_cost: total_cost,
@@ -60,6 +143,8 @@ module ClaudeSwarm
       instances = {}
       # Track session resets per instance
       cost_tracking = {}
+      # Track main instance token costs
+      main_instance_costs = {}
 
       return instances unless File.exist?(session_log_path)
 
@@ -96,8 +181,21 @@ module ClaudeSwarm
           instances[calling_instance][:calls_to] << instance_name
         end
 
-        # Track costs and calls
-        if data.dig("event", "type") == "result"
+        # Handle main instance token-based costs
+        if instance_id == "main" && data.dig("event", "type") == "assistant"
+          usage = data.dig("event", "message", "usage")
+          model = data.dig("event", "message", "model")
+          if usage && model
+            token_cost = calculate_token_cost(usage, model)
+            if token_cost > 0
+              main_instance_costs[instance_name] ||= 0.0
+              main_instance_costs[instance_name] += token_cost
+              instances[instance_name][:has_cost_data] = true
+              instances[instance_name][:calls] += 1
+            end
+          end
+        # Track costs and calls for other instances
+        elsif data.dig("event", "type") == "result"
           instances[instance_name][:calls] += 1
           if (cost = data.dig("event", "total_cost_usd"))
             # Initialize cost tracking for this instance
@@ -122,6 +220,11 @@ module ClaudeSwarm
         end
       rescue JSON::ParserError
         next
+      end
+
+      # Add main instance token costs to final totals
+      main_instance_costs.each do |name, cost|
+        instances[name][:cost] += cost if instances[name]
       end
 
       instances

--- a/test/commands/ps_test.rb
+++ b/test/commands/ps_test.rb
@@ -50,10 +50,10 @@ module ClaudeSwarm
         }
         File.write(File.join(@test_session_dir, "config.yml"), config.to_yaml)
 
-        # Create test JSON log with cumulative costs from same instance
+        # Create test JSON log with cost_usd from same instance
         json_log = [
-          { "instance" => "agent1", "event" => { "type" => "result", "total_cost_usd" => 0.1234 } },
-          { "instance" => "agent1", "event" => { "type" => "result", "total_cost_usd" => 0.2345 } },
+          { "instance" => "agent1", "event" => { "type" => "result", "cost_usd" => 0.1111 } },
+          { "instance" => "agent1", "event" => { "type" => "result", "cost_usd" => 0.1234 } },
           { "event" => { "type" => "other" } },
         ].map(&:to_json).join("\n")
         File.write(File.join(@test_session_dir, "session.log.json"), json_log)
@@ -70,10 +70,12 @@ module ClaudeSwarm
         assert_includes(output, "DIRECTORY")
         assert_match(/test-session-123/, output)
         assert_match(/Test Swarm/, output)
-        # Should show only the last cumulative cost for the instance
-        assert_match(/\$0\.2345/, output)
+        # Should show sum of costs for the instance with asterisk (no main instance cost)
+        assert_match(/\$0\.2345\*/, output)
         assert_match(/\d+s/, output) # Should show uptime
         assert_match(/\./, output) # Should show directory
+        # Should show warning about missing main instance costs
+        assert_match(/Total cost does not include the cost of the main instance/, output)
       end
 
       def test_execute_with_stale_symlink
@@ -93,6 +95,53 @@ module ClaudeSwarm
         output = capture_io { Commands::Ps.new.execute }.first
 
         assert_equal("No active sessions\n", output)
+      end
+
+      def test_execute_with_main_instance_costs
+        # Create test config
+        config = {
+          "swarm" => {
+            "name" => "Test Swarm",
+            "main" => "leader",
+            "instances" => {
+              "leader" => {
+                "directory" => ".",
+              },
+            },
+          },
+        }
+        File.write(File.join(@test_session_dir, "config.yml"), config.to_yaml)
+
+        # Create test JSON log with main instance token costs
+        json_log = [
+          {
+            "instance" => "leader",
+            "instance_id" => "main",
+            "event" => {
+              "type" => "assistant",
+              "message" => {
+                "model" => "claude-3-5-sonnet-20241022",
+                "usage" => {
+                  "input_tokens" => 1000,
+                  "output_tokens" => 500,
+                },
+              },
+            },
+          },
+          { "instance" => "agent1", "event" => { "type" => "result", "cost_usd" => 0.10 } },
+        ].map(&:to_json).join("\n")
+        File.write(File.join(@test_session_dir, "session.log.json"), json_log)
+
+        # Create symlink
+        File.symlink(@test_session_dir, File.join(@run_dir, "test-session-123"))
+
+        output = capture_io { Commands::Ps.new.execute }.first
+
+        # Should NOT show warning about missing main instance costs
+        refute_match(/Total cost does not include the cost of the main instance/, output)
+        # Should NOT have asterisk on cost (main instance cost included)
+        assert_match(/\$0\.1/, output)
+        refute_match(/\$0\.\d+\*/, output)
       end
 
       def test_execute_with_no_json_log

--- a/test/commands/ps_test.rb
+++ b/test/commands/ps_test.rb
@@ -50,10 +50,10 @@ module ClaudeSwarm
         }
         File.write(File.join(@test_session_dir, "config.yml"), config.to_yaml)
 
-        # Create test JSON log with costs
+        # Create test JSON log with cumulative costs from same instance
         json_log = [
-          { "event" => { "type" => "result", "total_cost_usd" => 0.1234 } },
-          { "event" => { "type" => "result", "total_cost_usd" => 0.2345 } },
+          { "instance" => "agent1", "event" => { "type" => "result", "total_cost_usd" => 0.1234 } },
+          { "instance" => "agent1", "event" => { "type" => "result", "total_cost_usd" => 0.2345 } },
           { "event" => { "type" => "other" } },
         ].map(&:to_json).join("\n")
         File.write(File.join(@test_session_dir, "session.log.json"), json_log)
@@ -70,7 +70,8 @@ module ClaudeSwarm
         assert_includes(output, "DIRECTORY")
         assert_match(/test-session-123/, output)
         assert_match(/Test Swarm/, output)
-        assert_match(/\$0\.3579/, output)
+        # Should show only the last cumulative cost for the instance
+        assert_match(/\$0\.2345/, output)
         assert_match(/\d+s/, output) # Should show uptime
         assert_match(/\./, output) # Should show directory
       end

--- a/test/commands/show_main_instance_test.rb
+++ b/test/commands/show_main_instance_test.rb
@@ -64,13 +64,13 @@ module ClaudeSwarm
               },
             },
           },
-          # Other instance with cumulative cost
+          # Other instance with cost_usd
           {
             "instance" => "worker",
             "instance_id" => "worker_123",
             "calling_instance" => "lead_developer",
             "calling_instance_id" => "main",
-            "event" => { "type" => "result", "total_cost_usd" => 0.05 },
+            "event" => { "type" => "result", "cost_usd" => 0.05 },
           },
         ].map(&:to_json).join("\n")
         File.write(File.join(@session_path, "session.log.json"), json_log)
@@ -124,7 +124,7 @@ module ClaudeSwarm
           {
             "instance" => "worker",
             "instance_id" => "worker_123",
-            "event" => { "type" => "result", "total_cost_usd" => 0.10 },
+            "event" => { "type" => "result", "cost_usd" => 0.10 },
           },
         ].map(&:to_json).join("\n")
         File.write(File.join(@session_path, "session.log.json"), json_log)

--- a/test/commands/show_main_instance_test.rb
+++ b/test/commands/show_main_instance_test.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "claude_swarm/commands/show"
+require "tempfile"
+require "yaml"
+require "json"
+
+module ClaudeSwarm
+  module Commands
+    class ShowMainInstanceTest < Minitest::Test
+      def setup
+        @tmpdir = Dir.mktmpdir
+        @session_id = "test-session-123"
+        @session_path = File.join(@tmpdir, @session_id)
+        FileUtils.mkdir_p(@session_path)
+      end
+
+      def teardown
+        FileUtils.rm_rf(@tmpdir)
+      end
+
+      def test_show_with_main_instance_token_costs
+        # Create config
+        config = {
+          "swarm" => {
+            "name" => "Test Swarm",
+            "main" => "lead_developer",
+          },
+        }
+        File.write(File.join(@session_path, "config.yml"), config.to_yaml)
+
+        # Create session log with main instance token costs and other instance costs
+        json_log = [
+          # Main instance message with Opus model
+          {
+            "instance" => "lead_developer",
+            "instance_id" => "main",
+            "event" => {
+              "type" => "assistant",
+              "message" => {
+                "model" => "claude-opus-4-1-20250805",
+                "usage" => {
+                  "input_tokens" => 1000,
+                  "output_tokens" => 500,
+                  "cache_creation_input_tokens" => 0,
+                  "cache_read_input_tokens" => 0,
+                },
+              },
+            },
+          },
+          # Another main instance message
+          {
+            "instance" => "lead_developer",
+            "instance_id" => "main",
+            "event" => {
+              "type" => "assistant",
+              "message" => {
+                "model" => "claude-opus-4-1-20250805",
+                "usage" => {
+                  "input_tokens" => 2000,
+                  "output_tokens" => 1000,
+                },
+              },
+            },
+          },
+          # Other instance with cumulative cost
+          {
+            "instance" => "worker",
+            "instance_id" => "worker_123",
+            "calling_instance" => "lead_developer",
+            "calling_instance_id" => "main",
+            "event" => { "type" => "result", "total_cost_usd" => 0.05 },
+          },
+        ].map(&:to_json).join("\n")
+        File.write(File.join(@session_path, "session.log.json"), json_log)
+
+        # Create run symlink in the expected location
+        run_dir = File.expand_path("~/.claude-swarm/run")
+        FileUtils.mkdir_p(run_dir)
+        symlink_path = File.join(run_dir, @session_id)
+        File.unlink(symlink_path) if File.symlink?(symlink_path)
+        File.symlink(@session_path, symlink_path)
+
+        begin
+          output = capture_io { Show.new.execute(@session_id) }.first
+
+          # Check that main instance is shown with cost
+          assert_match(/lead_developer \[main\]/, output)
+
+          # Calculate expected main instance cost:
+          # First message: 1000/1M * $15 + 500/1M * $75 = $0.015 + $0.0375 = $0.0525
+          # Second message: 2000/1M * $15 + 1000/1M * $75 = $0.03 + $0.075 = $0.105
+          # Total main: $0.0525 + $0.105 = $0.1575
+          # Worker: $0.05
+          # Grand total: $0.1575 + $0.05 = $0.2075
+
+          # Check total cost includes main instance
+          assert_match(/Total Cost: \$0\.2075/, output)
+
+          # Should NOT show "(excluding main instance)" message
+          refute_match(/excluding main instance/, output)
+
+          # Check that the main instance shows cost (not "n/a")
+          refute_match(%r{n/a \(interactive\)}, output)
+        ensure
+          # Clean up symlink
+          File.unlink(symlink_path) if File.symlink?(symlink_path)
+        end
+      end
+
+      def test_show_without_main_instance_costs
+        # Create config
+        config = {
+          "swarm" => {
+            "name" => "Test Swarm",
+            "main" => "lead_developer",
+          },
+        }
+        File.write(File.join(@session_path, "config.yml"), config.to_yaml)
+
+        # Create session log with only other instance costs (no main instance data)
+        json_log = [
+          {
+            "instance" => "worker",
+            "instance_id" => "worker_123",
+            "event" => { "type" => "result", "total_cost_usd" => 0.10 },
+          },
+        ].map(&:to_json).join("\n")
+        File.write(File.join(@session_path, "session.log.json"), json_log)
+
+        # Create run symlink in the expected location
+        run_dir = File.expand_path("~/.claude-swarm/run")
+        FileUtils.mkdir_p(run_dir)
+        symlink_path = File.join(run_dir, @session_id)
+        File.unlink(symlink_path) if File.symlink?(symlink_path)
+        File.symlink(@session_path, symlink_path)
+
+        begin
+          output = capture_io { Show.new.execute(@session_id) }.first
+
+          # Should show "(excluding main instance)" when main has no cost data
+          assert_match(/\$0\.1000 \(excluding main instance\)/, output)
+
+          # Note about main instance not being tracked
+          assert_match(/Note: Main instance \(lead_developer\) cost is not tracked/, output)
+        ensure
+          # Clean up symlink
+          File.unlink(symlink_path) if File.symlink?(symlink_path)
+        end
+      end
+    end
+  end
+end

--- a/test/commands/show_test.rb
+++ b/test/commands/show_test.rb
@@ -74,7 +74,7 @@ module ClaudeSwarm
         json_log = {
           "instance" => "orchestrator",
           "instance_id" => "orchestrator_123",
-          "event" => { "type" => "result", "total_cost_usd" => 0.5 },
+          "event" => { "type" => "result", "cost_usd" => 0.5 },
         }.to_json
         File.write(File.join(@test_session_dir, "session.log.json"), json_log)
 
@@ -164,17 +164,17 @@ module ClaudeSwarm
           {
             "instance" => "frontend",
             "instance_id" => "frontend_123",
-            "event" => { "type" => "result", "total_cost_usd" => 0.1 },
+            "event" => { "type" => "result", "cost_usd" => 0.1 },
           },
           {
             "instance" => "backend",
             "instance_id" => "backend_123",
-            "event" => { "type" => "result", "total_cost_usd" => 0.2 },
+            "event" => { "type" => "result", "cost_usd" => 0.2 },
           },
           {
             "instance" => "database",
             "instance_id" => "database_123",
-            "event" => { "type" => "result", "total_cost_usd" => 0.05 },
+            "event" => { "type" => "result", "cost_usd" => 0.05 },
           },
         ].map(&:to_json).join("\n")
 
@@ -238,7 +238,7 @@ module ClaudeSwarm
           {
             "instance" => "worker",
             "instance_id" => "worker_123",
-            "event" => { "type" => "result", "total_cost_usd" => 0.3579 },
+            "event" => { "type" => "result", "cost_usd" => 0.3579 },
           },
         ].map(&:to_json).join("\n")
 

--- a/test/orchestrator_transcript_test.rb
+++ b/test/orchestrator_transcript_test.rb
@@ -99,9 +99,9 @@ class OrchestratorTranscriptTest < Minitest::Test
     assert_equal("lead", first_entry["instance"])
     assert_equal("main", first_entry["instance_id"])
     assert(first_entry["timestamp"])
-    assert_equal("transcript", first_entry["event"]["type"])
-    assert_equal("main_instance", first_entry["event"]["source"])
-    assert(first_entry["event"]["data"])
+    assert_equal("request", first_entry["event"]["type"])
+    assert_equal("user", first_entry["event"]["from_instance"])
+    assert(first_entry["event"]["prompt"])
 
     # Clean up thread
     thread.terminate
@@ -144,7 +144,7 @@ class OrchestratorTranscriptTest < Minitest::Test
     entries = File.readlines(session_json).map { |line| JSON.parse(line) }
 
     assert_equal(1, entries.size)
-    assert_equal("user", entries.first["event"]["data"]["type"])
+    assert_equal("request", entries.first["event"]["type"])
 
     # Clean up thread
     thread.terminate
@@ -235,9 +235,9 @@ class OrchestratorTranscriptTest < Minitest::Test
     assert_equal("lead", result[:instance])
     assert_equal("main", result[:instance_id])
     assert_equal("2025-01-01T00:00:00Z", result[:timestamp])
-    assert_equal("transcript", result[:event][:type])
-    assert_equal("main_instance", result[:event][:source])
-    assert_equal(transcript_entry, result[:event][:data])
+    assert_equal("request", result[:event][:type])
+    assert_equal("user", result[:event][:from_instance])
+    assert_equal("test message", result[:event][:prompt])
   end
 
   def test_convert_transcript_without_timestamp
@@ -254,6 +254,8 @@ class OrchestratorTranscriptTest < Minitest::Test
     # Should have generated timestamp
     assert(result[:timestamp])
     assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, result[:timestamp])
+    assert_equal("request", result[:event][:type])
+    assert_equal("test message", result[:event][:prompt])
   end
 
   def test_transcript_tailing_skips_summary_entries
@@ -290,11 +292,11 @@ class OrchestratorTranscriptTest < Minitest::Test
     assert_equal(2, entries.size)
 
     # Verify the entries are the correct ones
-    assert_equal("user", entries[0]["event"]["data"]["type"])
-    assert_equal("Hello", entries[0]["event"]["data"]["message"])
+    assert_equal("request", entries[0]["event"]["type"])
+    assert_equal("Hello", entries[0]["event"]["prompt"])
 
-    assert_equal("assistant", entries[1]["event"]["data"]["type"])
-    assert_equal("Hi there", entries[1]["event"]["data"]["message"])
+    assert_equal("assistant", entries[1]["event"]["type"])
+    assert_equal("Hi there", entries[1]["event"]["message"]["content"][0]["text"])
 
     # Clean up thread
     thread.terminate
@@ -331,8 +333,8 @@ class OrchestratorTranscriptTest < Minitest::Test
 
     # Should have both existing entries
     assert_equal(2, entries.size)
-    assert_equal("First entry", entries[0]["event"]["data"]["message"])
-    assert_equal("Second entry", entries[1]["event"]["data"]["message"])
+    assert_equal("First entry", entries[0]["event"]["prompt"])
+    assert_equal("Second entry", entries[1]["event"]["message"]["content"][0]["text"])
 
     # Now add a new entry
     File.open(transcript_file, "a") do |f|
@@ -347,7 +349,7 @@ class OrchestratorTranscriptTest < Minitest::Test
 
     # Should now have 3 entries total
     assert_equal(3, entries.size)
-    assert_equal("Third entry", entries[2]["event"]["data"]["message"])
+    assert_equal("Third entry", entries[2]["event"]["prompt"])
 
     # Clean up thread
     thread.terminate

--- a/test/session_cost_calculator_test.rb
+++ b/test/session_cost_calculator_test.rb
@@ -1,0 +1,143 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "tempfile"
+require "json"
+
+class SessionCostCalculatorTest < Minitest::Test
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @session_log_path = File.join(@tmpdir, "session.log.json")
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_calculate_total_cost_with_cumulative_costs
+    # Create session log with cumulative costs
+    File.open(@session_log_path, "w") do |f|
+      # Instance 1: Multiple results with cumulative costs
+      f.puts({
+        instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.05 },
+      }.to_json)
+      f.puts({
+        instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.10 },
+      }.to_json)
+      f.puts({
+        instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.15 },
+      }.to_json)
+
+      # Instance 2: Multiple results with cumulative costs
+      f.puts({
+        instance: "agent2",
+        event: { type: "result", total_cost_usd: 0.02 },
+      }.to_json)
+      f.puts({
+        instance: "agent2",
+        event: { type: "result", total_cost_usd: 0.07 },
+      }.to_json)
+
+      # Instance 3: Single result
+      f.puts({
+        instance: "agent3",
+        event: { type: "result", total_cost_usd: 0.03 },
+      }.to_json)
+    end
+
+    result = ClaudeSwarm::SessionCostCalculator.calculate_total_cost(@session_log_path)
+
+    # Total should be: 0.15 (last from agent1) + 0.07 (last from agent2) + 0.03 (from agent3) = 0.25
+    assert_in_delta(0.25, result[:total_cost], 0.001)
+    assert_equal(Set.new(["agent1", "agent2", "agent3"]), result[:instances_with_cost])
+  end
+
+  def test_calculate_total_cost_with_no_costs
+    # Create session log without cost data
+    File.open(@session_log_path, "w") do |f|
+      f.puts({
+        instance: "agent1",
+        event: { type: "request" },
+      }.to_json)
+      f.puts({
+        instance: "agent1",
+        event: { type: "assistant" },
+      }.to_json)
+    end
+
+    result = ClaudeSwarm::SessionCostCalculator.calculate_total_cost(@session_log_path)
+
+    assert_in_delta(0.0, result[:total_cost])
+    assert_equal(Set.new, result[:instances_with_cost])
+  end
+
+  def test_calculate_total_cost_with_missing_file
+    result = ClaudeSwarm::SessionCostCalculator.calculate_total_cost("/nonexistent/path")
+
+    assert_in_delta(0.0, result[:total_cost])
+    assert_equal(Set.new, result[:instances_with_cost])
+  end
+
+  def test_parse_instance_hierarchy_with_cumulative_costs
+    # Create session log with relationships and cumulative costs
+    File.open(@session_log_path, "w") do |f|
+      # Agent1 calls agent2
+      f.puts({
+        instance: "agent2",
+        instance_id: "agent2_123",
+        calling_instance: "agent1",
+        calling_instance_id: "agent1_456",
+        event: { type: "request" },
+      }.to_json)
+
+      # Agent2 first result
+      f.puts({
+        instance: "agent2",
+        instance_id: "agent2_123",
+        calling_instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.05 },
+      }.to_json)
+
+      # Agent2 second result (cumulative)
+      f.puts({
+        instance: "agent2",
+        instance_id: "agent2_123",
+        calling_instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.12 },
+      }.to_json)
+    end
+
+    instances = ClaudeSwarm::SessionCostCalculator.parse_instance_hierarchy(@session_log_path)
+
+    # Agent2 should have the last cumulative cost (0.12), not the sum
+    assert_in_delta(0.12, instances["agent2"][:cost])
+    assert_equal(2, instances["agent2"][:calls])
+    assert(instances["agent2"][:has_cost_data])
+
+    # Check relationships
+    assert_equal(Set.new(["agent1"]), instances["agent2"][:called_by])
+    assert_equal(Set.new(["agent2"]), instances["agent1"][:calls_to])
+  end
+
+  def test_calculate_simple_total
+    # Create session log
+    File.open(@session_log_path, "w") do |f|
+      f.puts({
+        instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.05 },
+      }.to_json)
+      f.puts({
+        instance: "agent1",
+        event: { type: "result", total_cost_usd: 0.10 },
+      }.to_json)
+    end
+
+    total = ClaudeSwarm::SessionCostCalculator.calculate_simple_total(@session_log_path)
+
+    # Should return just the last cumulative cost
+    assert_in_delta(0.10, total, 0.001)
+  end
+end


### PR DESCRIPTION
## Summary
- Fixed main instance log format in interactive mode to match other instance logs
- Simplified cost calculation by using non-cumulative `cost_usd` instead of cumulative `total_cost_usd`
- Added token-based cost calculation for main instance in interactive mode

## Changes

### Log Format Fix
- Converted transcript wrapper format to standard request/assistant format
- Main instance logs now have consistent structure with other instances
- Properly extracts text content from nested message structures

### Cost Calculation Improvements
- **Before**: Used `total_cost_usd` (cumulative) requiring complex session reset detection
- **After**: Uses `cost_usd` (per-request) with simple summation - much cleaner\!
- Main instance costs calculated from token usage with accurate model pricing:
  - Opus: $15/MTok input, $75/MTok output, $18.75/MTok cache write, $1.50/MTok cache read
  - Sonnet: $3/MTok input, $15/MTok output, $3.75/MTok cache write, $0.30/MTok cache read
  - Haiku: $0.80/MTok input, $4/MTok output, $1/MTok cache write, $0.08/MTok cache read

### PS Command Enhancements
- Smart warning display: Only shows when sessions are missing main instance costs
- Visual indicator: Adds asterisk (*) to costs that exclude main instance
- Accurate cost display for all sessions

### Backward Compatibility
- Gracefully handles sessions without main instance token data
- Shows "n/a (interactive)" for main instance when cost data unavailable
- Displays helpful note when main instance costs aren't tracked

## Test Coverage
- All existing tests updated to use `cost_usd`
- Added tests for token-based cost calculation
- Added tests for PS command with/without main instance costs
- Removed obsolete session reset tests

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>