### PR TITLE
Fix: Expand mkdir brace expansion to individual commands in test

### DIFF
--- a/test/orchestrator_before_commands_create_directory_test.rb
+++ b/test/orchestrator_before_commands_create_directory_test.rb
@@ -33,8 +33,13 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
         main: lead
         before:
           - echo "Creating directories..."
-          - mkdir -p ./team_assessments/{evidence,reports,sessions,data}
-          - mkdir -p ./team_assessments/evidence/{vault,google,data}
+          - mkdir -p ./team_assessments/evidence
+          - mkdir -p ./team_assessments/reports
+          - mkdir -p ./team_assessments/sessions
+          - mkdir -p ./team_assessments/data
+          - mkdir -p ./team_assessments/evidence/vault
+          - mkdir -p ./team_assessments/evidence/google
+          - mkdir -p ./team_assessments/evidence/data
         instances:
           lead:
             description: "Lead developer"


### PR DESCRIPTION
## Description

This PR expands the brace expansion syntax in mkdir commands to individual mkdir commands in the orchestrator before commands test.

## Changes

- Replaced `mkdir -p ./team_assessments/{evidence,reports,sessions,data}` with individual mkdir commands
- Replaced `mkdir -p ./team_assessments/evidence/{vault,google,data}` with individual mkdir commands

## Rationale

This change improves:
- **Compatibility**: Not all shells support brace expansion in the same way
- **Clarity**: Makes it explicit which directories are being created
- **Maintainability**: Easier to understand and modify individual commands

## Testing

The test continues to verify that all expected directories are created by the before commands.