### PR TITLE
Enable branch coverage in SimpleCov configuration

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@
 require "simplecov"
 SimpleCov.external_at_exit = true
 SimpleCov.start do
+  enable_coverage :branch
   add_filter "/test/"
   add_filter "/vendor/"
   add_filter "/version.rb"


### PR DESCRIPTION
## Description
This PR enables branch coverage in the SimpleCov test coverage configuration.

## Changes
- Added `enable_coverage :branch` to the SimpleCov configuration in `test/test_helper.rb`

## Benefits
- Provides more detailed test coverage metrics
- Shows which branches in conditional statements are covered by tests
- Helps identify untested code paths in if/else statements, case statements, and ternary operators

## Testing
- Run tests with `rake test` to verify coverage still works correctly
- Check coverage report to see branch coverage metrics included