### PR TITLE
Use chdir parameter for subprocess execution instead of Dir.chdir

### DIFF
--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -41,7 +41,27 @@ module ClaudeSwarm
 
   class << self
     def root_dir
-      ENV.fetch("CLAUDE_SWARM_ROOT_DIR", Dir.pwd)
+      ENV.fetch("CLAUDE_SWARM_ROOT_DIR") { Dir.pwd }
+    end
+
+    def home_dir
+      ENV.fetch("CLAUDE_SWARM_HOME") { File.expand_path("~/.claude-swarm") }
+    end
+
+    def joined_home_dir(*strings)
+      File.join(home_dir, *strings)
+    end
+
+    def joined_run_dir(*strings)
+      joined_home_dir("run", *strings)
+    end
+
+    def joined_sessions_dir(*strings)
+      joined_home_dir("sessions", *strings)
+    end
+
+    def joined_worktrees_dir(*strings)
+      joined_home_dir("worktrees", *strings)
     end
   end
 end

--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -40,10 +40,6 @@ module ClaudeSwarm
   class Error < StandardError; end
 
   class << self
-    def root_dir
-      ENV.fetch("CLAUDE_SWARM_ROOT_DIR") { Dir.pwd }
-    end
-
     def home_dir
       ENV.fetch("CLAUDE_SWARM_HOME") { File.expand_path("~/.claude-swarm") }
     end

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -406,12 +406,12 @@ module ClaudeSwarm
       desc: "Number of lines to show initially"
     def watch(session_id)
       # Find session path
-      run_symlink = File.join(File.expand_path("~/.claude-swarm/run"), session_id)
+      run_symlink = ClaudeSwarm.joined_run_dir(session_id)
       session_path = if File.symlink?(run_symlink)
         File.readlink(run_symlink)
       else
         # Search in sessions directory
-        Dir.glob(File.expand_path("~/.claude-swarm/sessions/*/*")).find do |path|
+        Dir.glob(ClaudeSwarm.joined_sessions_dir("*", "*")).find do |path|
           File.basename(path) == session_id
         end
       end
@@ -437,7 +437,7 @@ module ClaudeSwarm
       default: 10,
       desc: "Maximum number of sessions to display"
     def list_sessions
-      sessions_dir = File.expand_path("~/.claude-swarm/sessions")
+      sessions_dir = ClaudeSwarm.joined_sessions_dir
       unless Dir.exist?(sessions_dir)
         say("No sessions found", :yellow)
         return
@@ -590,7 +590,7 @@ module ClaudeSwarm
     end
 
     def find_session_path(session_id)
-      sessions_dir = File.expand_path("~/.claude-swarm/sessions")
+      sessions_dir = ClaudeSwarm.joined_sessions_dir
 
       # Search for the session ID in all projects
       Dir.glob("#{sessions_dir}/*/#{session_id}").each do |path|
@@ -602,7 +602,7 @@ module ClaudeSwarm
     end
 
     def clean_stale_symlinks(days)
-      run_dir = File.expand_path("~/.claude-swarm/run")
+      run_dir = ClaudeSwarm.joined_run_dir
       return 0 unless Dir.exist?(run_dir)
 
       cleaned = 0
@@ -631,10 +631,10 @@ module ClaudeSwarm
     end
 
     def clean_orphaned_worktrees(days)
-      worktrees_dir = File.expand_path("~/.claude-swarm/worktrees")
+      worktrees_dir = ClaudeSwarm.joined_worktrees_dir
       return 0 unless Dir.exist?(worktrees_dir)
 
-      sessions_dir = File.expand_path("~/.claude-swarm/sessions")
+      sessions_dir = ClaudeSwarm.joined_sessions_dir
       cleaned = 0
 
       Dir.glob("#{worktrees_dir}/*").each do |session_worktree_dir|

--- a/lib/claude_swarm/cli.rb
+++ b/lib/claude_swarm/cli.rb
@@ -42,9 +42,8 @@ module ClaudeSwarm
       type: :string,
       desc: "Root directory for resolving relative paths (defaults to current directory)"
     def start(config_file = nil)
-      # Set root directory early so it's available to all components
-      root_dir = options[:root_dir] || Dir.pwd
-      ENV["CLAUDE_SWARM_ROOT_DIR"] = File.expand_path(root_dir)
+      # Determine root directory for this session
+      root_dir = File.expand_path(options[:root_dir] || Dir.pwd)
 
       # Resolve config path relative to root directory
       config_path = config_file || "claude-swarm.yml"
@@ -70,7 +69,7 @@ module ClaudeSwarm
       end
 
       begin
-        config = Configuration.new(config_path, base_dir: ClaudeSwarm.root_dir, options: options)
+        config = Configuration.new(config_path, base_dir: root_dir, options: options)
         generator = McpGenerator.new(config, vibe: options[:vibe])
         orchestrator = Orchestrator.new(
           config,
@@ -540,24 +539,23 @@ module ClaudeSwarm
           exit(1)
         end
 
-        # Change to the original root directory if it exists
+        # Load the original root directory from session
         root_dir_file = File.join(session_path, "root_directory")
-        if File.exist?(root_dir_file)
+        root_dir = if File.exist?(root_dir_file)
           original_dir = File.read(root_dir_file).strip
           if Dir.exist?(original_dir)
-            Dir.chdir(original_dir)
-            ENV["CLAUDE_SWARM_ROOT_DIR"] = original_dir
-            say("Changed to original directory: #{original_dir}", :green) unless options[:prompt]
+            say("Using original directory: #{original_dir}", :green) unless options[:prompt]
+            original_dir
           else
             error("Original directory no longer exists: #{original_dir}")
             exit(1)
           end
         else
           # If no root_directory file, use current directory
-          ENV["CLAUDE_SWARM_ROOT_DIR"] = Dir.pwd
+          Dir.pwd
         end
 
-        config = Configuration.new(config_file, base_dir: ClaudeSwarm.root_dir)
+        config = Configuration.new(config_file, base_dir: root_dir)
 
         # Load session metadata if it exists to check for worktree info
         session_metadata_file = File.join(session_path, "session_metadata.json")

--- a/lib/claude_swarm/commands/ps.rb
+++ b/lib/claude_swarm/commands/ps.rb
@@ -3,10 +3,9 @@
 module ClaudeSwarm
   module Commands
     class Ps
-      RUN_DIR = File.expand_path("~/.claude-swarm/run")
-
       def execute
-        unless Dir.exist?(RUN_DIR)
+        run_dir = ClaudeSwarm.joined_run_dir
+        unless Dir.exist?(run_dir)
           puts "No active sessions"
           return
         end
@@ -14,7 +13,7 @@ module ClaudeSwarm
         sessions = []
 
         # Read all symlinks in run directory
-        Dir.glob("#{RUN_DIR}/*").each do |symlink|
+        Dir.glob("#{run_dir}/*").each do |symlink|
           next unless File.symlink?(symlink)
 
           begin

--- a/lib/claude_swarm/commands/ps.rb
+++ b/lib/claude_swarm/commands/ps.rb
@@ -95,9 +95,8 @@ module ClaudeSwarm
         main_instance = config.dig("swarm", "main")
 
         # Get base directory from session metadata or root_directory file
-        base_dir = ClaudeSwarm.root_dir
         root_dir_file = File.join(session_dir, "root_directory")
-        base_dir = File.read(root_dir_file).strip if File.exist?(root_dir_file)
+        base_dir = File.exist?(root_dir_file) ? File.read(root_dir_file).strip : Dir.pwd
 
         # Get all directories - handle both string and array formats
         dir_config = config.dig("swarm", "instances", main_instance, "directory")

--- a/lib/claude_swarm/commands/show.rb
+++ b/lib/claude_swarm/commands/show.rb
@@ -63,14 +63,14 @@ module ClaudeSwarm
 
       def find_session_path(session_id)
         # First check the run directory
-        run_symlink = File.join(File.expand_path("~/.claude-swarm/run"), session_id)
+        run_symlink = ClaudeSwarm.joined_run_dir(session_id)
         if File.symlink?(run_symlink)
           target = File.readlink(run_symlink)
           return target if Dir.exist?(target)
         end
 
         # Fall back to searching all sessions
-        Dir.glob(File.expand_path("~/.claude-swarm/sessions/*/*")).find do |path|
+        Dir.glob(ClaudeSwarm.joined_sessions_dir("*", "*")).find do |path|
           File.basename(path) == session_id
         end
       end

--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -13,12 +13,12 @@ module ClaudeSwarm
     ENV_VAR_WITH_DEFAULT_PATTERN = /\$\{([^:}]+)(:=([^}]*))?\}/
     O_SERIES_MODEL_PATTERN = /^o\d+(\s+(Preview|preview))?(-pro|-mini|-deep-research|-mini-deep-research)?$/
 
-    attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances
+    attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances, :base_dir
 
     def initialize(config_path, base_dir: nil, options: {})
       @config_path = Pathname.new(config_path).expand_path
       @config_dir = @config_path.dirname
-      @base_dir = base_dir || @config_dir
+      @base_dir = base_dir || @config_dir.to_s
       @options = options
       load_and_validate
     end

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -6,7 +6,6 @@ module ClaudeSwarm
 
     attr_reader :config, :session_path, :session_log_path
 
-    RUN_DIR = File.expand_path("~/.claude-swarm/run")
     ["INT", "TERM", "QUIT"].each do |signal|
       Signal.trap(signal) do
         puts "\n🛑 Received #{signal} signal."
@@ -437,11 +436,12 @@ module ClaudeSwarm
     def create_run_symlink
       return unless @session_path
 
-      FileUtils.mkdir_p(RUN_DIR)
+      run_dir = ClaudeSwarm.joined_run_dir
+      FileUtils.mkdir_p(run_dir)
 
       # Session ID is the last part of the session path
       session_id = File.basename(@session_path)
-      symlink_path = File.join(RUN_DIR, session_id)
+      symlink_path = ClaudeSwarm.joined_run_dir(session_id)
 
       # Remove stale symlink if exists
       File.unlink(symlink_path) if File.symlink?(symlink_path)
@@ -457,7 +457,7 @@ module ClaudeSwarm
       return unless @session_path
 
       session_id = File.basename(@session_path)
-      symlink_path = File.join(RUN_DIR, session_id)
+      symlink_path = ClaudeSwarm.joined_run_dir(session_id)
       File.unlink(symlink_path) if File.symlink?(symlink_path)
     rescue StandardError
       # Ignore errors during cleanup

--- a/lib/claude_swarm/orchestrator.rb
+++ b/lib/claude_swarm/orchestrator.rb
@@ -44,7 +44,7 @@ module ClaudeSwarm
         @session_log_path = File.join(@session_path, "session.log")
       else
         # Generate new session path
-        session_params = { working_dir: ClaudeSwarm.root_dir }
+        session_params = { working_dir: @config.base_dir }
         session_params[:session_id] = @provided_session_id if @provided_session_id
         @session_path = SessionPath.generate(**session_params)
         SessionPath.ensure_directory(@session_path)
@@ -55,7 +55,6 @@ module ClaudeSwarm
 
       end
       ENV["CLAUDE_SWARM_SESSION_PATH"] = @session_path
-      ENV["CLAUDE_SWARM_ROOT_DIR"] = ClaudeSwarm.root_dir
 
       # Initialize components that depend on session path
       @process_tracker = ProcessTracker.new(@session_path)
@@ -222,15 +221,13 @@ module ClaudeSwarm
           before_commands_dir = parent_dir
         end
 
-        Dir.chdir(before_commands_dir) do
-          success = execute_before_commands?(before_commands)
-          unless success
-            non_interactive_output { print("❌ Before commands failed. Aborting swarm launch.") }
-            cleanup_processes
-            cleanup_run_symlink
-            cleanup_worktrees
-            exit(1)
-          end
+        success = execute_before_commands?(before_commands, chdir: before_commands_dir)
+        unless success
+          non_interactive_output { print("❌ Before commands failed. Aborting swarm launch.") }
+          cleanup_processes
+          cleanup_run_symlink
+          cleanup_worktrees
+          exit(1)
         end
 
         non_interactive_output do
@@ -253,16 +250,15 @@ module ClaudeSwarm
       end
 
       # Execute the main instance - this will cascade to other instances via MCP
-      Dir.chdir(main_instance[:directory]) do
-        # Execute main Claude instance with unbundled environment to avoid bundler conflicts
-        # This ensures the main instance runs in a clean environment without inheriting
-        # Claude Swarm's BUNDLE_* environment variables
-        Bundler.with_unbundled_env do
-          if @non_interactive_prompt
-            stream_to_session_log(*command)
-          else
-            system!(*command)
-          end
+      # Execute main Claude instance with unbundled environment to avoid bundler conflicts
+      # This ensures the main instance runs in a clean environment without inheriting
+      # Claude Swarm's BUNDLE_* environment variables
+      main_dir = main_instance[:directory]
+      Bundler.with_unbundled_env do
+        if @non_interactive_prompt
+          stream_to_session_log(*command, chdir: main_dir)
+        else
+          system!(*command, chdir: main_dir)
         end
       end
 
@@ -292,16 +288,14 @@ module ClaudeSwarm
           after_commands_dir = parent_dir
         end
 
-        Dir.chdir(after_commands_dir) do
-          non_interactive_output do
-            print("⚙️  Executing after commands...")
-          end
+        non_interactive_output do
+          print("⚙️  Executing after commands...")
+        end
 
-          success = execute_after_commands?(after_commands)
-          unless success
-            non_interactive_output do
-              puts "⚠️  Some after commands failed"
-            end
+        success = execute_after_commands?(after_commands, chdir: after_commands_dir)
+        unless success
+          non_interactive_output do
+            puts "⚠️  Some after commands failed"
           end
         end
       end
@@ -319,12 +313,12 @@ module ClaudeSwarm
       puts
     end
 
-    def execute_before_commands?(commands)
-      execute_commands(commands, phase: "before", fail_fast: true)
+    def execute_before_commands?(commands, chdir:)
+      execute_commands(commands, phase: "before", fail_fast: true, chdir: chdir)
     end
 
-    def execute_after_commands?(commands)
-      execute_commands(commands, phase: "after", fail_fast: false)
+    def execute_after_commands?(commands, chdir:)
+      execute_commands(commands, phase: "after", fail_fast: false, chdir: chdir)
     end
 
     def save_swarm_config_path(session_path)
@@ -334,7 +328,7 @@ module ClaudeSwarm
 
       # Save the root directory
       root_dir_file = File.join(session_path, "root_directory")
-      File.write(root_dir_file, ClaudeSwarm.root_dir)
+      File.write(root_dir_file, @config.base_dir)
 
       # Save session metadata
       metadata_file = File.join(session_path, "session_metadata.json")
@@ -343,7 +337,7 @@ module ClaudeSwarm
 
     def build_session_metadata
       {
-        "root_directory" => ClaudeSwarm.root_dir,
+        "root_directory" => @config.base_dir,
         "timestamp" => Time.now.utc.iso8601,
         "start_time" => @start_time.utc.iso8601,
         "swarm_name" => @config.swarm_name,
@@ -619,12 +613,12 @@ module ClaudeSwarm
       end
     end
 
-    def stream_to_session_log(*command)
+    def stream_to_session_log(*command, chdir:)
       # Setup logger for session logging
       logger = Logger.new(@session_log_path, level: :info, progname: @config.main_instance)
 
       # Use Open3.popen2e to capture stdout and stderr merged for formatting
-      Open3.popen2e(*command) do |stdin, stdout_and_stderr, wait_thr|
+      Open3.popen2e(*command, chdir: chdir) do |stdin, stdout_and_stderr, wait_thr|
         stdin.close
 
         # Read and process the merged output
@@ -796,7 +790,10 @@ module ClaudeSwarm
       @logger ||= Logger.new(File.join(@session_path, "session.log"), level: :info, progname: "orchestrator")
     end
 
-    def execute_commands(commands, phase:, fail_fast:)
+    def execute_commands(commands, phase:, fail_fast:, chdir:)
+      raise ArgumentError, "chdir parameter is required" if chdir.nil?
+      raise ArgumentError, "chdir must be a valid directory: #{chdir}" unless File.directory?(chdir)
+
       all_succeeded = true
 
       # Setup logger for session logging if we have a session path
@@ -815,13 +812,15 @@ module ClaudeSwarm
             end
           end
 
-          output = %x(#{command} 2>&1)
-          success = $CHILD_STATUS.success?
+          # Use Open3.capture2e with chdir option to execute the command
+          # This allows setting the working directory without changing the process directory
+          output, status = Open3.capture2e(command, chdir: chdir)
+          success = status.success?
           output_separator = "-" * 80
 
           logger.info { "Command output:" }
           logger.info { output }
-          logger.info { "Exit status: #{$CHILD_STATUS.exitstatus}" }
+          logger.info { "Exit status: #{status.exitstatus}" }
           logger.info { output_separator }
 
           # Show output if in debug mode or if command failed
@@ -830,7 +829,7 @@ module ClaudeSwarm
               output_prefix = phase == "after" ? "After command" : "Command"
               puts "#{output_prefix} #{index + 1} output:"
               puts output
-              print("Exit status: #{$CHILD_STATUS.exitstatus}")
+              print("Exit status: #{status.exitstatus}")
             end
           end
 

--- a/lib/claude_swarm/session_path.rb
+++ b/lib/claude_swarm/session_path.rb
@@ -2,13 +2,7 @@
 
 module ClaudeSwarm
   module SessionPath
-    SESSIONS_DIR = "sessions"
-
     class << self
-      def swarm_home
-        ENV["CLAUDE_SWARM_HOME"] || File.expand_path("~/.claude-swarm")
-      end
-
       # Convert a directory path to a safe folder name using + as separator
       def project_folder_name(working_dir = Dir.pwd)
         # Don't expand path if it's already expanded (avoids double expansion on Windows)
@@ -27,7 +21,7 @@ module ClaudeSwarm
       # Generate a full session path for a given directory and session ID
       def generate(working_dir: Dir.pwd, session_id: SecureRandom.uuid)
         project_name = project_folder_name(working_dir)
-        File.join(swarm_home, SESSIONS_DIR, project_name, session_id)
+        ClaudeSwarm.joined_sessions_dir(project_name, session_id)
       end
 
       # Ensure the session directory exists
@@ -35,7 +29,7 @@ module ClaudeSwarm
         FileUtils.mkdir_p(session_path)
 
         # Add .gitignore to swarm home if it doesn't exist
-        gitignore_path = File.join(swarm_home, ".gitignore")
+        gitignore_path = ClaudeSwarm.joined_home_dir(".gitignore")
         File.write(gitignore_path, "*\n") unless File.exist?(gitignore_path)
       end
 

--- a/lib/claude_swarm/system_utils.rb
+++ b/lib/claude_swarm/system_utils.rb
@@ -2,10 +2,21 @@
 
 module ClaudeSwarm
   module SystemUtils
-    def system!(*args)
-      success = system(*args)
+    def system!(*args, chdir: nil)
+      # Build options hash for system/spawn
+      options = {}
+      options[:chdir] = chdir if chdir
+
+      # Call system with options if chdir is provided, otherwise use original behavior
+      success = if chdir
+        system(*args, **options)
+      else
+        system(*args)
+      end
+
+      exit_status = $CHILD_STATUS&.exitstatus || 1
+
       unless success
-        exit_status = $CHILD_STATUS&.exitstatus || 1
         command_str = args.size == 1 ? args.first : args.join(" ")
         if exit_status == 143 # timeout command exit status = 128 + 15 (SIGTERM)
           warn("⏱️ Command timeout: #{command_str}")

--- a/lib/claude_swarm/worktree_manager.rb
+++ b/lib/claude_swarm/worktree_manager.rb
@@ -158,7 +158,7 @@ module ClaudeSwarm
       # Remove session-specific worktree directory if it exists and is empty
       return unless @session_id
 
-      session_worktree_dir = File.join(File.expand_path("~/.claude-swarm/worktrees"), @session_id)
+      session_worktree_dir = ClaudeSwarm.joined_worktrees_dir(@session_id)
       return unless File.exist?(session_worktree_dir)
 
       # Try to remove the directory tree
@@ -214,7 +214,7 @@ module ClaudeSwarm
       unique_repo_name = "#{repo_name}-#{path_hash}"
 
       # Build external path: ~/.claude-swarm/worktrees/[session_id]/[repo_name-hash]/[worktree_name]
-      base_dir = File.expand_path("~/.claude-swarm/worktrees")
+      base_dir = ClaudeSwarm.joined_worktrees_dir
 
       # Validate base directory is accessible
       begin

--- a/test/claude_code_executor_test.rb
+++ b/test/claude_code_executor_test.rb
@@ -103,7 +103,7 @@ class ClaudeCodeExecutorTest < Minitest::Test
 
   def test_initialization_with_environment_session_path
     # Set environment variable
-    session_path = File.join(ClaudeSwarm::SessionPath.swarm_home, "sessions/test+project/20240102_123456")
+    session_path = ClaudeSwarm.joined_sessions_dir("test+project/20240102_123456")
     ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
 
     executor = ClaudeSwarm::ClaudeCodeExecutor.new(

--- a/test/claude_code_executor_test.rb
+++ b/test/claude_code_executor_test.rb
@@ -5,8 +5,6 @@ require "test_helper"
 class ClaudeCodeExecutorTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir
-    @original_dir = Dir.pwd
-    Dir.chdir(@tmpdir)
 
     # Set up session path for tests
     @session_path = File.join(@tmpdir, "test_session")
@@ -20,7 +18,6 @@ class ClaudeCodeExecutorTest < Minitest::Test
   end
 
   def teardown
-    Dir.chdir(@original_dir)
     FileUtils.rm_rf(@tmpdir)
     ENV.delete("CLAUDE_SWARM_SESSION_PATH")
   end

--- a/test/claude_mcp_server_test.rb
+++ b/test/claude_mcp_server_test.rb
@@ -63,7 +63,7 @@ class ClaudeMcpServerTest < Minitest::Test
   end
 
   def test_logging_with_environment_session_path
-    session_path = File.join(ClaudeSwarm::SessionPath.swarm_home, "sessions/test+project/20240101_120000")
+    session_path = ClaudeSwarm.joined_sessions_dir("test+project/20240101_120000")
     ENV["CLAUDE_SWARM_SESSION_PATH"] = session_path
 
     ClaudeSwarm::ClaudeMcpServer.new(@instance_config, calling_instance: "test_caller", debug: false)

--- a/test/claude_mcp_server_test.rb
+++ b/test/claude_mcp_server_test.rb
@@ -5,8 +5,6 @@ require "test_helper"
 class ClaudeMcpServerTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir
-    @original_dir = Dir.pwd
-    Dir.chdir(@tmpdir)
 
     @instance_config = {
       name: "test_instance",
@@ -35,7 +33,6 @@ class ClaudeMcpServerTest < Minitest::Test
   end
 
   def teardown
-    Dir.chdir(@original_dir)
     FileUtils.rm_rf(@tmpdir)
     ENV["CLAUDE_SWARM_SESSION_PATH"] = @original_env if @original_env
 

--- a/test/cli_commands_test.rb
+++ b/test/cli_commands_test.rb
@@ -6,8 +6,8 @@ module ClaudeSwarm
   class CLICommandsTest < Minitest::Test
     def setup
       @cli = CLI.new
-      @run_dir = File.expand_path("~/.claude-swarm/run")
-      @test_session_dir = File.expand_path("~/.claude-swarm/sessions/test-project/test-session-123")
+      @run_dir = ClaudeSwarm.joined_run_dir
+      @test_session_dir = ClaudeSwarm.joined_sessions_dir("test-project", "test-session-123")
 
       # Clean up any existing test data
       FileUtils.rm_rf(@run_dir)
@@ -75,7 +75,7 @@ module ClaudeSwarm
 
     def test_clean_command_with_days_option
       # Create an old symlink
-      old_session_dir = File.expand_path("~/.claude-swarm/sessions/test-project/old-session")
+      old_session_dir = ClaudeSwarm.joined_sessions_dir("test-project", "old-session")
       FileUtils.mkdir_p(old_session_dir)
       symlink_path = File.join(@run_dir, "old-session")
       File.symlink(old_session_dir, symlink_path)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -5,18 +5,17 @@ require "test_helper"
 class CLITest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir
-    @original_dir = Dir.pwd
-    Dir.chdir(@tmpdir)
     @cli = ClaudeSwarm::CLI.new
   end
 
   def teardown
-    Dir.chdir(@original_dir)
     FileUtils.rm_rf(@tmpdir)
   end
 
   def write_config(filename, content)
-    File.write(filename, content)
+    path = File.join(@tmpdir, filename)
+    File.write(path, content)
+    path
   end
 
   def capture_cli_output(&)
@@ -44,15 +43,15 @@ class CLITest < Minitest::Test
   end
 
   def test_start_with_invalid_yaml
-    write_config("invalid.yml", "invalid: yaml: syntax:")
+    config_path = write_config("invalid.yml", "invalid: yaml: syntax:")
 
     assert_raises(SystemExit) do
-      capture_cli_output { @cli.start("invalid.yml") }
+      capture_cli_output { @cli.start(config_path) }
     end
   end
 
   def test_start_with_configuration_error
-    write_config("bad-config.yml", <<~YAML)
+    config_path = write_config("bad-config.yml", <<~YAML)
       version: 2
       swarm:
         name: "Test"
@@ -64,14 +63,14 @@ class CLITest < Minitest::Test
     YAML
 
     _, err = capture_cli_output do
-      assert_raises(SystemExit) { @cli.start("bad-config.yml") }
+      assert_raises(SystemExit) { @cli.start(config_path) }
     end
 
     assert_match(/Unsupported version/, err)
   end
 
   def test_start_with_valid_config
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -87,14 +86,14 @@ class CLITest < Minitest::Test
     orchestrator_mock.expect(:start, nil)
 
     ClaudeSwarm::Orchestrator.stub(:new, orchestrator_mock) do
-      capture_cli_output { @cli.start("valid.yml") }
+      capture_cli_output { @cli.start(config_path) }
     end
 
     orchestrator_mock.verify
   end
 
   def test_start_with_options
-    write_config("custom.yml", <<~YAML)
+    config_path = write_config("custom.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -111,14 +110,14 @@ class CLITest < Minitest::Test
     orchestrator_mock.expect(:start, nil)
 
     ClaudeSwarm::Orchestrator.stub(:new, orchestrator_mock) do
-      capture_cli_output { @cli.start("custom.yml") }
+      capture_cli_output { @cli.start(config_path) }
     end
 
     orchestrator_mock.verify
   end
 
   def test_start_with_prompt_option
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -143,7 +142,7 @@ class CLITest < Minitest::Test
         assert_nil(options[:vibe])
         orchestrator_mock
       }) do
-        output, = capture_cli_output { @cli.start("valid.yml") }
+        output, = capture_cli_output { @cli.start(config_path) }
         # Verify that startup message is suppressed when prompt is provided
         refute_match(/Starting Claude Swarm/, output)
       end
@@ -153,7 +152,7 @@ class CLITest < Minitest::Test
   end
 
   def test_start_without_prompt_shows_message
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -170,7 +169,7 @@ class CLITest < Minitest::Test
     orchestrator_mock.expect(:start, nil)
 
     ClaudeSwarm::Orchestrator.stub(:new, orchestrator_mock) do
-      output, = capture_cli_output { @cli.start("valid.yml") }
+      output, = capture_cli_output { @cli.start(config_path) }
       # Verify that startup message is shown when prompt is not provided
       # The path is now expanded to absolute path
       assert_match(/Starting Claude Swarm from.*valid\.yml\.\.\./, output)
@@ -608,7 +607,7 @@ class CLITest < Minitest::Test
   end
 
   def test_start_unexpected_error_without_verbose
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -625,7 +624,7 @@ class CLITest < Minitest::Test
       raise StandardError, "Unexpected test error"
     }) do
       _, err = capture_cli_output do
-        assert_raises(SystemExit) { @cli.start("valid.yml") }
+        assert_raises(SystemExit) { @cli.start(config_path) }
       end
 
       assert_match(/Unexpected error: Unexpected test error/, err)
@@ -634,7 +633,7 @@ class CLITest < Minitest::Test
   end
 
   def test_start_unexpected_error_with_verbose
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -651,7 +650,7 @@ class CLITest < Minitest::Test
       raise StandardError, "Unexpected test error"
     }) do
       _, err = capture_cli_output do
-        assert_raises(SystemExit) { @cli.start("valid.yml") }
+        assert_raises(SystemExit) { @cli.start(config_path) }
       end
 
       assert_match(/Unexpected error: Unexpected test error/, err)
@@ -851,7 +850,7 @@ class CLITest < Minitest::Test
   end
 
   def test_start_with_session_id_option
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -874,7 +873,7 @@ class CLITest < Minitest::Test
         assert_equal("custom-session-456", options[:session_id])
         orchestrator_mock
       }) do
-        capture_cli_output { @cli.start("valid.yml") }
+        capture_cli_output { @cli.start(config_path) }
       end
     end
 
@@ -882,7 +881,7 @@ class CLITest < Minitest::Test
   end
 
   def test_start_with_multiple_options_including_session_id
-    write_config("valid.yml", <<~YAML)
+    config_path = write_config("valid.yml", <<~YAML)
       version: 1
       swarm:
         name: "Test"
@@ -913,7 +912,7 @@ class CLITest < Minitest::Test
         assert(options[:debug])
         orchestrator_mock
       }) do
-        capture_cli_output { @cli.start("valid.yml") }
+        capture_cli_output { @cli.start(config_path) }
       end
     end
 

--- a/test/commands/ps_test.rb
+++ b/test/commands/ps_test.rb
@@ -5,8 +5,8 @@ module ClaudeSwarm
   module Commands
     class PsTest < Minitest::Test
       def setup
-        @run_dir = File.expand_path("~/.claude-swarm/run")
-        @test_session_dir = File.expand_path("~/.claude-swarm/sessions/test-project/test-session-123")
+        @run_dir = ClaudeSwarm.joined_run_dir
+        @test_session_dir = ClaudeSwarm.joined_sessions_dir("test-project", "test-session-123")
 
         # Clean up any existing test data
         FileUtils.rm_rf(@run_dir)
@@ -208,8 +208,8 @@ module ClaudeSwarm
 
       def test_multiple_sessions_sorted_by_time
         # Create two sessions with different timestamps
-        session1_dir = File.expand_path("~/.claude-swarm/sessions/test-project/session-1")
-        session2_dir = File.expand_path("~/.claude-swarm/sessions/test-project/session-2")
+        session1_dir = ClaudeSwarm.joined_sessions_dir("test-project", "session-1")
+        session2_dir = ClaudeSwarm.joined_sessions_dir("test-project", "session-2")
 
         [session1_dir, session2_dir].each_with_index do |dir, i|
           FileUtils.mkdir_p(dir)

--- a/test/commands/show_main_instance_test.rb
+++ b/test/commands/show_main_instance_test.rb
@@ -76,9 +76,9 @@ module ClaudeSwarm
         File.write(File.join(@session_path, "session.log.json"), json_log)
 
         # Create run symlink in the expected location
-        run_dir = File.expand_path("~/.claude-swarm/run")
+        run_dir = ClaudeSwarm.joined_run_dir
         FileUtils.mkdir_p(run_dir)
-        symlink_path = File.join(run_dir, @session_id)
+        symlink_path = ClaudeSwarm.joined_run_dir(@session_id)
         File.unlink(symlink_path) if File.symlink?(symlink_path)
         File.symlink(@session_path, symlink_path)
 
@@ -130,9 +130,9 @@ module ClaudeSwarm
         File.write(File.join(@session_path, "session.log.json"), json_log)
 
         # Create run symlink in the expected location
-        run_dir = File.expand_path("~/.claude-swarm/run")
+        run_dir = ClaudeSwarm.joined_run_dir
         FileUtils.mkdir_p(run_dir)
-        symlink_path = File.join(run_dir, @session_id)
+        symlink_path = ClaudeSwarm.joined_run_dir(@session_id)
         File.unlink(symlink_path) if File.symlink?(symlink_path)
         File.symlink(@session_path, symlink_path)
 

--- a/test/commands/show_test.rb
+++ b/test/commands/show_test.rb
@@ -6,8 +6,8 @@ module ClaudeSwarm
   module Commands
     class ShowTest < Minitest::Test
       def setup
-        @run_dir = File.expand_path("~/.claude-swarm/run")
-        @test_session_dir = File.expand_path("~/.claude-swarm/sessions/test-project/test-session-123")
+        @run_dir = ClaudeSwarm.joined_run_dir
+        @test_session_dir = ClaudeSwarm.joined_sessions_dir("test-project", "test-session-123")
 
         # Clean up any existing test data
         FileUtils.rm_rf(@run_dir)

--- a/test/configuration_before_commands_test.rb
+++ b/test/configuration_before_commands_test.rb
@@ -36,28 +36,26 @@ class ConfigurationBeforeCommandsTest < Minitest::Test
 
     # Should not raise even though ./frontend doesn't exist yet
     # because before commands are present
-    Dir.chdir(@temp_dir) do
-      config = ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
+    config = ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
 
-      # Verify the configuration loaded successfully
-      assert_equal("Test Swarm", config.swarm_name)
-      assert_equal("lead", config.main_instance)
-      assert_equal(["mkdir -p ./frontend"], config.before_commands)
+    # Verify the configuration loaded successfully
+    assert_equal("Test Swarm", config.swarm_name)
+    assert_equal("lead", config.main_instance)
+    assert_equal(["mkdir -p ./frontend"], config.before_commands)
 
-      # Directory doesn't exist yet
-      refute(File.directory?(File.join(@temp_dir, "frontend")))
+    # Directory doesn't exist yet
+    refute(File.directory?(File.join(@temp_dir, "frontend")))
 
-      # But validate_directories would fail if called explicitly
-      assert_raises(ClaudeSwarm::Error) do
-        config.validate_directories
-      end
-
-      # Create the directory (simulating what before_commands would do)
-      FileUtils.mkdir_p(File.join(@temp_dir, "frontend"))
-
-      # Now validate_directories should pass without raising
-      config.validate_directories # Should not raise
+    # But validate_directories would fail if called explicitly
+    assert_raises(ClaudeSwarm::Error) do
+      config.validate_directories
     end
+
+    # Create the directory (simulating what before_commands would do)
+    FileUtils.mkdir_p(File.join(@temp_dir, "frontend"))
+
+    # Now validate_directories should pass without raising
+    config.validate_directories # Should not raise
   end
 
   def test_validates_directories_when_no_before_commands
@@ -80,12 +78,10 @@ class ConfigurationBeforeCommandsTest < Minitest::Test
     YAML
 
     # Should raise because ./frontend doesn't exist and no before commands
-    Dir.chdir(@temp_dir) do
-      error = assert_raises(ClaudeSwarm::Error) do
-        ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
-      end
-      assert_match(/Directory.*frontend.*does not exist/, error.message)
+    error = assert_raises(ClaudeSwarm::Error) do
+      ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
     end
+    assert_match(/Directory.*frontend.*does not exist/, error.message)
   end
 
   def test_validates_directories_with_empty_before_commands
@@ -109,11 +105,9 @@ class ConfigurationBeforeCommandsTest < Minitest::Test
     YAML
 
     # Should raise because before commands is empty
-    Dir.chdir(@temp_dir) do
-      error = assert_raises(ClaudeSwarm::Error) do
-        ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
-      end
-      assert_match(/Directory.*frontend.*does not exist/, error.message)
+    error = assert_raises(ClaudeSwarm::Error) do
+      ClaudeSwarm::Configuration.new(config_path, base_dir: @temp_dir)
     end
+    assert_match(/Directory.*frontend.*does not exist/, error.message)
   end
 end

--- a/test/helpers/test_helpers.rb
+++ b/test/helpers/test_helpers.rb
@@ -271,7 +271,7 @@ module TestHelpers
     def calculate_worktree_path(repo_dir, worktree_name, session_id = "default")
       repo_name = File.basename(repo_dir)
       repo_hash = Digest::SHA256.hexdigest(repo_dir)[0..7]
-      File.expand_path("~/.claude-swarm/worktrees/#{session_id}/#{repo_name}-#{repo_hash}/#{worktree_name}")
+      ClaudeSwarm.joined_worktrees_dir(session_id, "#{repo_name}-#{repo_hash}", worktree_name)
     end
   end
 

--- a/test/helpers/test_helpers.rb
+++ b/test/helpers/test_helpers.rb
@@ -7,7 +7,7 @@ module TestHelpers
         original_dir = Dir.pwd
         begin
           Dir.chdir(tmpdir)
-          yield tmpdir
+          yield(tmpdir)
         ensure
           Dir.chdir(original_dir)
         end

--- a/test/mcp_generator_args_test.rb
+++ b/test/mcp_generator_args_test.rb
@@ -37,55 +37,54 @@ class McpGeneratorArgsTest < Minitest::Test
 
   def test_mcp_config_generates_correct_args
     Dir.mktmpdir do |tmpdir|
-      Dir.chdir(tmpdir) do
-        # Write the config file
-        File.write("claude-swarm.yml", @config_content)
+      # Write the config file
+      config_path = File.join(tmpdir, "claude-swarm.yml")
+      File.write(config_path, @config_content)
 
-        # Create required directories
-        Dir.mkdir("backend")
+      # Create required directories
+      Dir.mkdir(File.join(tmpdir, "backend"))
 
-        # Create the configuration and generator
-        config = ClaudeSwarm::Configuration.new("claude-swarm.yml")
-        generator = ClaudeSwarm::McpGenerator.new(config)
+      # Create the configuration and generator
+      config = ClaudeSwarm::Configuration.new(config_path, base_dir: tmpdir)
+      generator = ClaudeSwarm::McpGenerator.new(config)
 
-        # Generate MCP configs
-        generator.generate_all
+      # Generate MCP configs
+      generator.generate_all
 
-        # Read the lead instance MCP config
-        lead_config = read_mcp_config("lead")
+      # Read the lead instance MCP config
+      lead_config = read_mcp_config("lead")
 
-        # Check that backend connection uses correct args format
-        backend_mcp = lead_config["mcpServers"]["backend"]
+      # Check that backend connection uses correct args format
+      backend_mcp = lead_config["mcpServers"]["backend"]
 
-        assert_equal("stdio", backend_mcp["type"])
-        assert_equal("claude-swarm", backend_mcp["command"])
+      assert_equal("stdio", backend_mcp["type"])
+      assert_equal("claude-swarm", backend_mcp["command"])
 
-        # Verify the args array
-        args = backend_mcp["args"]
+      # Verify the args array
+      args = backend_mcp["args"]
 
-        # Should start with mcp-serve command
-        assert_equal("mcp-serve", args[0])
+      # Should start with mcp-serve command
+      assert_equal("mcp-serve", args[0])
 
-        # Should have pairs of flag and value
-        assert_includes(args, "--name")
-        assert_includes(args, "backend")
-        assert_includes(args, "--directory")
-        assert_includes(args, File.expand_path("./backend"))
-        assert_includes(args, "--model")
-        assert_includes(args, "sonnet")
-        assert_includes(args, "--prompt")
-        assert_includes(args, "You are a backend dev")
-        assert_includes(args, "--allowed-tools")
+      # Should have pairs of flag and value
+      assert_includes(args, "--name")
+      assert_includes(args, "backend")
+      assert_includes(args, "--directory")
+      assert_includes(args, File.join(tmpdir, "backend"))
+      assert_includes(args, "--model")
+      assert_includes(args, "sonnet")
+      assert_includes(args, "--prompt")
+      assert_includes(args, "You are a backend dev")
+      assert_includes(args, "--allowed-tools")
 
-        # Tools should be after --allowed-tools flag as comma-separated
-        tools_index = args.index("--allowed-tools")
+      # Tools should be after --allowed-tools flag as comma-separated
+      tools_index = args.index("--allowed-tools")
 
-        assert_equal("Bash,Grep", args[tools_index + 1])
+      assert_equal("Bash,Grep", args[tools_index + 1])
 
-        # Should include MCP config path
-        assert_includes(args, "--mcp-config-path")
-        assert(args[args.index("--mcp-config-path") + 1].end_with?("backend.mcp.json"))
-      end
+      # Should include MCP config path
+      assert_includes(args, "--mcp-config-path")
+      assert(args[args.index("--mcp-config-path") + 1].end_with?("backend.mcp.json"))
     end
   end
 
@@ -113,75 +112,73 @@ class McpGeneratorArgsTest < Minitest::Test
     YAML
 
     Dir.mktmpdir do |tmpdir|
-      Dir.chdir(tmpdir) do
-        # Write the config file
-        File.write("claude-swarm.yml", openai_config)
+      # Write the config file
+      config_path = File.join(tmpdir, "claude-swarm.yml")
+      File.write(config_path, openai_config)
 
-        # Set environment variable for test
-        ENV["CUSTOM_OPENAI_KEY"] = "sk-test-key"
+      # Set environment variable for test
+      ENV["CUSTOM_OPENAI_KEY"] = "sk-test-key"
 
-        # Create the configuration and generator
-        config = ClaudeSwarm::Configuration.new("claude-swarm.yml")
-        generator = ClaudeSwarm::McpGenerator.new(config)
+      # Create the configuration and generator
+      config = ClaudeSwarm::Configuration.new(config_path, base_dir: tmpdir)
+      generator = ClaudeSwarm::McpGenerator.new(config)
 
-        # Generate MCP configs
-        generator.generate_all
+      # Generate MCP configs
+      generator.generate_all
 
-        # Read the lead instance MCP config
-        lead_config = read_mcp_config("lead")
+      # Read the lead instance MCP config
+      lead_config = read_mcp_config("lead")
 
-        # Check that ai_helper connection includes OpenAI provider args
-        ai_helper_mcp = lead_config["mcpServers"]["ai_helper"]
-        args = ai_helper_mcp["args"]
+      # Check that ai_helper connection includes OpenAI provider args
+      ai_helper_mcp = lead_config["mcpServers"]["ai_helper"]
+      args = ai_helper_mcp["args"]
 
-        # Should include provider and OpenAI-specific args
-        assert_includes(args, "--provider")
-        assert_includes(args, "openai")
-        assert_includes(args, "--temperature")
-        assert_includes(args, "0.7")
-        assert_includes(args, "--api-version")
-        assert_includes(args, "responses")
-        assert_includes(args, "--openai-token-env")
-        assert_includes(args, "CUSTOM_OPENAI_KEY")
-        assert_includes(args, "--base-url")
-        assert_includes(args, "https://custom.openai.com/v1")
+      # Should include provider and OpenAI-specific args
+      assert_includes(args, "--provider")
+      assert_includes(args, "openai")
+      assert_includes(args, "--temperature")
+      assert_includes(args, "0.7")
+      assert_includes(args, "--api-version")
+      assert_includes(args, "responses")
+      assert_includes(args, "--openai-token-env")
+      assert_includes(args, "CUSTOM_OPENAI_KEY")
+      assert_includes(args, "--base-url")
+      assert_includes(args, "https://custom.openai.com/v1")
 
-        # Should have vibe flag for OpenAI instances
-        assert_includes(args, "--vibe")
-      end
+      # Should have vibe flag for OpenAI instances
+      assert_includes(args, "--vibe")
     end
   end
 
   def test_mcp_config_without_provider_no_openai_args
     Dir.mktmpdir do |tmpdir|
-      Dir.chdir(tmpdir) do
-        # Write the config file (default Claude provider)
-        File.write("claude-swarm.yml", @config_content)
+      # Write the config file (default Claude provider)
+      config_path = File.join(tmpdir, "claude-swarm.yml")
+      File.write(config_path, @config_content)
 
-        # Create required directories
-        Dir.mkdir("backend")
+      # Create required directories
+      Dir.mkdir(File.join(tmpdir, "backend"))
 
-        # Create the configuration and generator
-        config = ClaudeSwarm::Configuration.new("claude-swarm.yml")
-        generator = ClaudeSwarm::McpGenerator.new(config)
+      # Create the configuration and generator
+      config = ClaudeSwarm::Configuration.new(config_path, base_dir: tmpdir)
+      generator = ClaudeSwarm::McpGenerator.new(config)
 
-        # Generate MCP configs
-        generator.generate_all
+      # Generate MCP configs
+      generator.generate_all
 
-        # Read the lead instance MCP config
-        lead_config = read_mcp_config("lead")
+      # Read the lead instance MCP config
+      lead_config = read_mcp_config("lead")
 
-        # Check that backend connection doesn't have OpenAI args
-        backend_mcp = lead_config["mcpServers"]["backend"]
-        args = backend_mcp["args"]
+      # Check that backend connection doesn't have OpenAI args
+      backend_mcp = lead_config["mcpServers"]["backend"]
+      args = backend_mcp["args"]
 
-        # Should NOT include OpenAI-specific args
-        refute_includes(args, "--provider")
-        refute_includes(args, "--temperature")
-        refute_includes(args, "--api-version")
-        refute_includes(args, "--openai-token-env")
-        refute_includes(args, "--base-url")
-      end
+      # Should NOT include OpenAI-specific args
+      refute_includes(args, "--provider")
+      refute_includes(args, "--temperature")
+      refute_includes(args, "--api-version")
+      refute_includes(args, "--openai-token-env")
+      refute_includes(args, "--base-url")
     end
   ensure
     ENV.delete("CUSTOM_OPENAI_KEY")

--- a/test/mcp_generator_test.rb
+++ b/test/mcp_generator_test.rb
@@ -33,11 +33,9 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      assert(Dir.exist?(@session_path), "Expected session directory to exist")
-    end
+    assert(Dir.exist?(@session_path), "Expected session directory to exist")
   end
 
   def test_generate_main_instance_config
@@ -72,56 +70,54 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Read generated config
-      mcp_config = read_mcp_config("lead")
+    # Read generated config
+    mcp_config = read_mcp_config("lead")
 
-      # Check mcpServers section
-      assert(mcp_config.key?("mcpServers"))
-      servers = mcp_config["mcpServers"]
+    # Check mcpServers section
+    assert(mcp_config.key?("mcpServers"))
+    servers = mcp_config["mcpServers"]
 
-      # Check backend connection
-      assert(servers.key?("backend"))
-      backend = servers["backend"]
+    # Check backend connection
+    assert(servers.key?("backend"))
+    backend = servers["backend"]
 
-      assert_equal("stdio", backend["type"])
-      assert_equal("claude-swarm", backend["command"])
+    assert_equal("stdio", backend["type"])
+    assert_equal("claude-swarm", backend["command"])
 
-      args = backend["args"]
+    args = backend["args"]
 
-      assert_equal("mcp-serve", args[0])
-      assert_includes(args, "--name")
-      assert_includes(args, "backend")
-      assert_includes(args, "--directory")
-      # Check that the directory arg is present - it may have different path formats
-      dir_index = args.index("--directory")
+    assert_equal("mcp-serve", args[0])
+    assert_includes(args, "--name")
+    assert_includes(args, "backend")
+    assert_includes(args, "--directory")
+    # Check that the directory arg is present - it may have different path formats
+    dir_index = args.index("--directory")
 
-      assert(dir_index, "Should have --directory flag")
-      assert(args[dir_index + 1].end_with?("backend"), "Directory should end with 'backend'")
-      assert_includes(args, "--model")
-      assert_includes(args, "claude-3-5-haiku-20241022")
-      assert_includes(args, "--prompt")
-      assert_includes(args, "Backend developer")
-      assert_includes(args, "--allowed-tools")
-      assert_includes(args, "Bash,Grep")
+    assert(dir_index, "Should have --directory flag")
+    assert(args[dir_index + 1].end_with?("backend"), "Directory should end with 'backend'")
+    assert_includes(args, "--model")
+    assert_includes(args, "claude-3-5-haiku-20241022")
+    assert_includes(args, "--prompt")
+    assert_includes(args, "Backend developer")
+    assert_includes(args, "--allowed-tools")
+    assert_includes(args, "Bash,Grep")
 
-      # Check frontend connection
-      assert(servers.key?("frontend"))
-      frontend = servers["frontend"]
+    # Check frontend connection
+    assert(servers.key?("frontend"))
+    frontend = servers["frontend"]
 
-      assert_equal("stdio", frontend["type"])
-      assert_equal("claude-swarm", frontend["command"])
+    assert_equal("stdio", frontend["type"])
+    assert_equal("claude-swarm", frontend["command"])
 
-      # Check custom MCP server
-      assert(servers.key?("test_server"))
-      test_server = servers["test_server"]
+    # Check custom MCP server
+    assert(servers.key?("test_server"))
+    test_server = servers["test_server"]
 
-      assert_equal("stdio", test_server["type"])
-      assert_equal("test-cmd", test_server["command"])
-      assert_equal(["--flag"], test_server["args"])
-    end
+    assert_equal("stdio", test_server["type"])
+    assert_equal("test-cmd", test_server["command"])
+    assert_equal(["--flag"], test_server["args"])
   end
 
   def test_sse_mcp_server
@@ -142,18 +138,16 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      mcp_config = read_mcp_config("lead")
+    mcp_config = read_mcp_config("lead")
 
-      api_server = mcp_config["mcpServers"]["api_server"]
+    api_server = mcp_config["mcpServers"]["api_server"]
 
-      assert_equal("sse", api_server["type"])
-      assert_equal("http://localhost:3000/events", api_server["url"])
-      assert_nil(api_server["command"])
-      assert_nil(api_server["args"])
-    end
+    assert_equal("sse", api_server["type"])
+    assert_equal("http://localhost:3000/events", api_server["url"])
+    assert_nil(api_server["command"])
+    assert_nil(api_server["args"])
   end
 
   def test_empty_tools_and_connections
@@ -170,14 +164,12 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      mcp_config = read_mcp_config("lead")
+    mcp_config = read_mcp_config("lead")
 
-      # Should have no MCP servers
-      assert_equal(0, mcp_config["mcpServers"].size)
-    end
+    # Should have no MCP servers
+    assert_equal(0, mcp_config["mcpServers"].size)
   end
 
   def test_generate_for_specific_instance
@@ -204,19 +196,17 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Check backend config has database connection
-      backend_config = read_mcp_config("backend")
+    # Check backend config has database connection
+    backend_config = read_mcp_config("backend")
 
-      assert(backend_config["mcpServers"].key?("database"))
+    assert(backend_config["mcpServers"].key?("database"))
 
-      # Check database config has no MCP servers
-      database_config = read_mcp_config("database")
+    # Check database config has no MCP servers
+    database_config = read_mcp_config("database")
 
-      assert_equal(0, database_config["mcpServers"].size)
-    end
+    assert_equal(0, database_config["mcpServers"].size)
   end
 
   def test_mcp_config_path_in_args
@@ -238,21 +228,19 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      lead_config = read_mcp_config("lead")
-      worker_args = lead_config["mcpServers"]["worker"]["args"]
+    lead_config = read_mcp_config("lead")
+    worker_args = lead_config["mcpServers"]["worker"]["args"]
 
-      mcp_path_index = worker_args.index("--mcp-config-path")
+    mcp_path_index = worker_args.index("--mcp-config-path")
 
-      assert(mcp_path_index, "Should include --mcp-config-path flag")
+    assert(mcp_path_index, "Should include --mcp-config-path flag")
 
-      mcp_path = worker_args[mcp_path_index + 1]
+    mcp_path = worker_args[mcp_path_index + 1]
 
-      assert(mcp_path.end_with?("worker.mcp.json"))
-      assert_path_exists(mcp_path)
-    end
+    assert(mcp_path.end_with?("worker.mcp.json"))
+    assert_path_exists(mcp_path)
   end
 
   def test_preserves_mcp_args_array
@@ -274,16 +262,14 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      mcp_config = read_mcp_config("lead")
+    mcp_config = read_mcp_config("lead")
 
-      server = mcp_config["mcpServers"]["complex_server"]
-      expected_args = ["--port", "3000", "--verbose", "--config", "/path/to/config.json"]
+    server = mcp_config["mcpServers"]["complex_server"]
+    expected_args = ["--port", "3000", "--verbose", "--config", "/path/to/config.json"]
 
-      assert_equal(expected_args, server["args"])
-    end
+    assert_equal(expected_args, server["args"])
   end
 
   def test_vibe_mode_no_mcp_servers
@@ -301,14 +287,12 @@ class McpGeneratorTest < Minitest::Test
     # Test with vibe mode enabled
     generator = ClaudeSwarm::McpGenerator.new(config, vibe: true)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      mcp_config = read_mcp_config("lead")
+    mcp_config = read_mcp_config("lead")
 
-      # In vibe mode, should have no MCPs
-      assert_empty(mcp_config["mcpServers"])
-    end
+    # In vibe mode, should have no MCPs
+    assert_empty(mcp_config["mcpServers"])
   end
 
   def test_instance_ids_are_generated
@@ -330,41 +314,39 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Check lead config has instance_id
-      lead_config = read_mcp_config("lead")
+    # Check lead config has instance_id
+    lead_config = read_mcp_config("lead")
 
-      assert(lead_config.key?("instance_id"))
-      assert(lead_config.key?("instance_name"))
-      assert_equal("lead", lead_config["instance_name"])
-      assert_match(/^lead_[a-f0-9]{8}$/, lead_config["instance_id"])
+    assert(lead_config.key?("instance_id"))
+    assert(lead_config.key?("instance_name"))
+    assert_equal("lead", lead_config["instance_name"])
+    assert_match(/^lead_[a-f0-9]{8}$/, lead_config["instance_id"])
 
-      # Check backend config has instance_id
-      backend_config = read_mcp_config("backend")
+    # Check backend config has instance_id
+    backend_config = read_mcp_config("backend")
 
-      assert(backend_config.key?("instance_id"))
-      assert(backend_config.key?("instance_name"))
-      assert_equal("backend", backend_config["instance_name"])
-      assert_match(/^backend_[a-f0-9]{8}$/, backend_config["instance_id"])
+    assert(backend_config.key?("instance_id"))
+    assert(backend_config.key?("instance_name"))
+    assert_equal("backend", backend_config["instance_name"])
+    assert_match(/^backend_[a-f0-9]{8}$/, backend_config["instance_id"])
 
-      # Check that connection includes calling_instance_id
-      backend_connection = lead_config["mcpServers"]["backend"]
+    # Check that connection includes calling_instance_id
+    backend_connection = lead_config["mcpServers"]["backend"]
 
-      assert_includes(backend_connection["args"], "--calling-instance-id")
+    assert_includes(backend_connection["args"], "--calling-instance-id")
 
-      calling_id_index = backend_connection["args"].index("--calling-instance-id") + 1
+    calling_id_index = backend_connection["args"].index("--calling-instance-id") + 1
 
-      assert_equal(lead_config["instance_id"], backend_connection["args"][calling_id_index])
+    assert_equal(lead_config["instance_id"], backend_connection["args"][calling_id_index])
 
-      # Check that connection includes instance_id for the target instance
-      assert_includes(backend_connection["args"], "--instance-id")
+    # Check that connection includes instance_id for the target instance
+    assert_includes(backend_connection["args"], "--instance-id")
 
-      instance_id_index = backend_connection["args"].index("--instance-id") + 1
+    instance_id_index = backend_connection["args"].index("--instance-id") + 1
 
-      assert_equal(backend_config["instance_id"], backend_connection["args"][instance_id_index])
-    end
+    assert_equal(backend_config["instance_id"], backend_connection["args"][instance_id_index])
   end
 
   def test_multiple_callers_get_different_ids
@@ -390,25 +372,23 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      lead_config = read_mcp_config("lead")
-      frontend_config = read_mcp_config("frontend")
+    lead_config = read_mcp_config("lead")
+    frontend_config = read_mcp_config("frontend")
 
-      # Both should have unique instance IDs
-      refute_equal(lead_config["instance_id"], frontend_config["instance_id"])
+    # Both should have unique instance IDs
+    refute_equal(lead_config["instance_id"], frontend_config["instance_id"])
 
-      # Check that shared service gets different calling_instance_ids from each caller
-      lead_shared_connection = lead_config["mcpServers"]["shared"]
-      frontend_shared_connection = frontend_config["mcpServers"]["shared"]
+    # Check that shared service gets different calling_instance_ids from each caller
+    lead_shared_connection = lead_config["mcpServers"]["shared"]
+    frontend_shared_connection = frontend_config["mcpServers"]["shared"]
 
-      lead_calling_id_index = lead_shared_connection["args"].index("--calling-instance-id") + 1
-      frontend_calling_id_index = frontend_shared_connection["args"].index("--calling-instance-id") + 1
+    lead_calling_id_index = lead_shared_connection["args"].index("--calling-instance-id") + 1
+    frontend_calling_id_index = frontend_shared_connection["args"].index("--calling-instance-id") + 1
 
-      assert_equal(lead_config["instance_id"], lead_shared_connection["args"][lead_calling_id_index])
-      assert_equal(frontend_config["instance_id"], frontend_shared_connection["args"][frontend_calling_id_index])
-    end
+    assert_equal(lead_config["instance_id"], lead_shared_connection["args"][lead_calling_id_index])
+    assert_equal(frontend_config["instance_id"], frontend_shared_connection["args"][frontend_calling_id_index])
   end
 
   def test_openai_instance_gets_claude_tools_mcp
@@ -435,20 +415,18 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Check that OpenAI instance has claude_tools MCP server
-      config_json = read_mcp_config("openai_assistant")
+    # Check that OpenAI instance has claude_tools MCP server
+    config_json = read_mcp_config("openai_assistant")
 
-      assert(config_json["mcpServers"].key?("claude_tools"), "OpenAI instance should have claude_tools MCP server")
+    assert(config_json["mcpServers"].key?("claude_tools"), "OpenAI instance should have claude_tools MCP server")
 
-      claude_tools_config = config_json["mcpServers"]["claude_tools"]
+    claude_tools_config = config_json["mcpServers"]["claude_tools"]
 
-      assert_equal("stdio", claude_tools_config["type"])
-      assert_equal("claude", claude_tools_config["command"])
-      assert_equal(["mcp", "serve"], claude_tools_config["args"])
-    end
+    assert_equal("stdio", claude_tools_config["type"])
+    assert_equal("claude", claude_tools_config["command"])
+    assert_equal(["mcp", "serve"], claude_tools_config["args"])
   ensure
     ENV.delete("OPENAI_API_KEY")
   end
@@ -469,14 +447,12 @@ class McpGeneratorTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Check that Claude instance does NOT have claude_tools MCP server
-      config_json = read_mcp_config("claude_assistant")
+    # Check that Claude instance does NOT have claude_tools MCP server
+    config_json = read_mcp_config("claude_assistant")
 
-      refute(config_json["mcpServers"].key?("claude_tools"), "Claude instance should NOT have claude_tools MCP server")
-    end
+    refute(config_json["mcpServers"].key?("claude_tools"), "Claude instance should NOT have claude_tools MCP server")
   end
 
   private

--- a/test/mcp_generator_vibe_test.rb
+++ b/test/mcp_generator_vibe_test.rb
@@ -41,13 +41,11 @@ class McpGeneratorVibeTest < Minitest::Test
     @config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(@config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
-      mcp_config = read_mcp_config("leader")
+    generator.generate_all
+    mcp_config = read_mcp_config("leader")
 
-      # Should have no MCPs when instance has vibe: true
-      assert_empty(mcp_config["mcpServers"])
-    end
+    # Should have no MCPs when instance has vibe: true
+    assert_empty(mcp_config["mcpServers"])
   end
 
   def test_global_vibe_no_mcps
@@ -66,13 +64,11 @@ class McpGeneratorVibeTest < Minitest::Test
     # Test with global vibe enabled
     generator = ClaudeSwarm::McpGenerator.new(@config, vibe: true)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
-      mcp_config = read_mcp_config("leader")
+    generator.generate_all
+    mcp_config = read_mcp_config("leader")
 
-      # Should have no MCPs when global vibe is true
-      assert_empty(mcp_config["mcpServers"])
-    end
+    # Should have no MCPs when global vibe is true
+    assert_empty(mcp_config["mcpServers"])
   end
 
   def test_mixed_vibe_instances
@@ -95,19 +91,17 @@ class McpGeneratorVibeTest < Minitest::Test
     @config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(@config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      # Leader should have worker MCP connection
-      leader_config = read_mcp_config("leader")
+    # Leader should have worker MCP connection
+    leader_config = read_mcp_config("leader")
 
-      assert(leader_config["mcpServers"].key?("worker"))
+    assert(leader_config["mcpServers"].key?("worker"))
 
-      # Worker should have no MCPs
-      worker_config = read_mcp_config("worker")
+    # Worker should have no MCPs
+    worker_config = read_mcp_config("worker")
 
-      assert_empty(worker_config["mcpServers"])
-    end
+    assert_empty(worker_config["mcpServers"])
   end
 
   def test_connection_args_include_vibe
@@ -128,14 +122,12 @@ class McpGeneratorVibeTest < Minitest::Test
     @config = ClaudeSwarm::Configuration.new(@config_path)
     generator = ClaudeSwarm::McpGenerator.new(@config)
 
-    Dir.chdir(@tmpdir) do
-      generator.generate_all
+    generator.generate_all
 
-      leader_config = read_mcp_config("leader")
-      worker_mcp = leader_config["mcpServers"]["worker"]
+    leader_config = read_mcp_config("leader")
+    worker_mcp = leader_config["mcpServers"]["worker"]
 
-      # Worker MCP should have --vibe flag
-      assert_includes(worker_mcp["args"], "--vibe")
-    end
+    # Worker MCP should have --vibe flag
+    assert_includes(worker_mcp["args"], "--vibe")
   end
 end

--- a/test/orchestrator_before_commands_create_directory_test.rb
+++ b/test/orchestrator_before_commands_create_directory_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/UnusedBlockArgument
 require "test_helper"
 require "tmpdir"
 require "fileutils"
@@ -10,7 +11,6 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
   def setup
     @tmpdir = Dir.mktmpdir("claude_swarm_test")
     @config_path = File.join(@tmpdir, "claude-swarm.yml")
-    Dir.chdir(@tmpdir)
 
     # Set environment variables for test
     ENV["CLAUDE_SWARM_SESSION_PATH"] = File.join(@tmpdir, ".claude-swarm", "sessions", "test")
@@ -18,7 +18,6 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
   end
 
   def teardown
-    Dir.chdir("/")
     FileUtils.rm_rf(@tmpdir)
     ENV.delete("CLAUDE_SWARM_SESSION_PATH")
     ENV.delete("CLAUDE_SWARM_ROOT_DIR")
@@ -55,7 +54,7 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     # Mock system! to prevent actual Claude execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -96,7 +95,7 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     # Mock system! to prevent actual Claude execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -119,3 +118,4 @@ class OrchestratorBeforeCommandsCreateDirectoryTest < Minitest::Test
     File.write(@config_path, content)
   end
 end
+# rubocop:enable Lint/UnusedBlockArgument

--- a/test/orchestrator_symlink_test.rb
+++ b/test/orchestrator_symlink_test.rb
@@ -8,7 +8,7 @@ module ClaudeSwarm
       @config = mock_configuration
       @generator = mock_generator
       @session_path = File.join(Dir.tmpdir, "claude-swarm-test-#{Time.now.to_i}")
-      @run_dir = File.expand_path("~/.claude-swarm/run")
+      @run_dir = ClaudeSwarm.joined_run_dir
 
       FileUtils.mkdir_p(@session_path)
       FileUtils.rm_rf(@run_dir)

--- a/test/orchestrator_symlink_test.rb
+++ b/test/orchestrator_symlink_test.rb
@@ -181,12 +181,13 @@ module ClaudeSwarm
     end
 
     class MockConfiguration
-      attr_reader :swarm_name, :main_instance, :config_path
+      attr_reader :swarm_name, :main_instance, :config_path, :base_dir
 
       def initialize
         @swarm_name = "Test Swarm"
         @main_instance = "leader"
         @config_path = "claude-swarm.yml"
+        @base_dir = Dir.pwd
       end
 
       def main_instance_config

--- a/test/orchestrator_test.rb
+++ b/test/orchestrator_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/UnusedBlockArgument
 require "test_helper"
 
 class OrchestratorTest < Minitest::Test
@@ -67,7 +68,6 @@ class OrchestratorTest < Minitest::Test
 
     # Test behavior, not format: environment variables should be set
     assert(ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil), "CLAUDE_SWARM_SESSION_PATH should be set")
-    assert(ENV.fetch("CLAUDE_SWARM_ROOT_DIR", nil), "CLAUDE_SWARM_ROOT_DIR should be set")
 
     # Session path should be available and match environment
     assert(orchestrator.session_path, "Orchestrator should have a session path")
@@ -85,20 +85,18 @@ class OrchestratorTest < Minitest::Test
     generator = ClaudeSwarm::McpGenerator.new(config)
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
-    Dir.chdir(@tmpdir) do
-      orchestrator.stub(:system, true) do
-        capture_io do
-          orchestrator.start
-        end
+    orchestrator.stub(:system, true) do
+      capture_io do
+        orchestrator.start
       end
-
-      # MCP files are now in ~/.claude-swarm, not in the current directory
-      session_path = ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil)
-
-      assert(session_path)
-      assert_path_exists(File.join(session_path, "lead.mcp.json"), "Expected lead.mcp.json to exist")
-      assert_path_exists(File.join(session_path, "backend.mcp.json"), "Expected backend.mcp.json to exist")
     end
+
+    # MCP files are now in ~/.claude-swarm, not in the current directory
+    session_path = ENV.fetch("CLAUDE_SWARM_SESSION_PATH", nil)
+
+    assert(session_path)
+    assert_path_exists(File.join(session_path, "lead.mcp.json"), "Expected lead.mcp.json to exist")
+    assert_path_exists(File.join(session_path, "backend.mcp.json"), "Expected backend.mcp.json to exist")
   end
 
   def test_start_creates_necessary_files_and_runs
@@ -130,9 +128,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Verify command array components
@@ -178,9 +174,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # When no tools are specified and vibe is false, neither flag should be present
@@ -209,9 +203,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     refute_includes(expected_command, "--append-system-prompt")
@@ -242,9 +234,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Verify arguments are passed correctly without manual escaping
@@ -299,9 +289,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Should include --settings flag
@@ -328,9 +316,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Should always include --settings flag for main instance (due to SessionStart hook)
@@ -386,13 +372,9 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
-    # Since we use Dir.chdir now, the path isn't part of the command
-    # Just verify the command was captured
     assert(expected_command, "Expected command should not be nil")
     assert_equal("claude", expected_command[0])
   end
@@ -407,9 +389,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Find MCP config path from command array
@@ -429,13 +409,11 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator, prompt: "Execute test task")
 
     expected_command = nil
-    orchestrator.stub(:stream_to_session_log, lambda { |*args|
+    orchestrator.stub(:stream_to_session_log, lambda { |*args, chdir: nil|
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Verify prompt is included in command
@@ -451,13 +429,11 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator, prompt: "Fix the 'bug' in module X")
 
     expected_command = nil
-    orchestrator.stub(:stream_to_session_log, lambda { |*args|
+    orchestrator.stub(:stream_to_session_log, lambda { |*args, chdir: nil|
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Verify prompt with quotes is passed correctly
@@ -473,7 +449,7 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator, prompt: "Test prompt")
 
     output = nil
-    orchestrator.stub(:stream_to_session_log, true) do
+    orchestrator.stub(:stream_to_session_log, lambda { |*_args, chdir: nil| true }) do
       output = capture_io { orchestrator.start }[0]
     end
 
@@ -512,7 +488,7 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator, prompt: "Debug test")
 
     output = nil
-    orchestrator.stub(:stream_to_session_log, true) do
+    orchestrator.stub(:stream_to_session_log, lambda { |*_args, chdir: nil| true }) do
       output = capture_io { orchestrator.start }[0]
     end
 
@@ -526,13 +502,11 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator, vibe: true, prompt: "Vibe test")
 
     expected_command = nil
-    orchestrator.stub(:stream_to_session_log, lambda { |*args|
+    orchestrator.stub(:stream_to_session_log, lambda { |*args, chdir: nil|
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Should include both vibe flag and prompt
@@ -553,9 +527,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Should add instance prompt via --append-system-prompt
@@ -586,9 +558,7 @@ class OrchestratorTest < Minitest::Test
       expected_command = args
       true
     }) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+      capture_io { orchestrator.start }
     end
 
     # Should not add --append-system-prompt when instance has no custom prompt
@@ -692,7 +662,7 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     # Mock system! to prevent actual execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -734,10 +704,8 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     # Mock system! to prevent actual execution
-    orchestrator.stub(:system!, true) do
-      Dir.chdir(@tmpdir) do
-        capture_io { orchestrator.start }
-      end
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
+      capture_io { orchestrator.start }
     end
 
     # Verify the before command was executed in the main instance directory
@@ -771,7 +739,7 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     system_called = false
-    orchestrator.stub(:system!, lambda { |*_args|
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil|
       system_called = true
       true
     }) do
@@ -782,10 +750,8 @@ class OrchestratorTest < Minitest::Test
               assert_equal(1, code, "Should exit with code 1 when before commands fail")
               raise SystemExit, "exit(#{code})"
             }) do
-              Dir.chdir(@tmpdir) do
-                assert_raises(SystemExit) do
-                  capture_io { orchestrator.start }
-                end
+              assert_raises(SystemExit) do
+                capture_io { orchestrator.start }
               end
             end
           end
@@ -844,12 +810,12 @@ class OrchestratorTest < Minitest::Test
       after_executed = false
 
       # Mock execute_after_commands to verify it's called
-      orchestrator.stub(:execute_after_commands?, lambda { |commands|
+      orchestrator.stub(:execute_after_commands?, lambda { |commands, chdir:|
         after_executed = true
 
         assert_equal(["echo 'Running after command' > after_output.txt"], commands)
-        # Actually execute the command for verification
-        commands.each { |cmd| system(cmd) }
+        # Actually execute the command for verification using the provided chdir
+        commands.each { |cmd| system(cmd, chdir: chdir) }
         true
       }) do
         orchestrator.stub(:system, lambda { |*_args|
@@ -859,9 +825,7 @@ class OrchestratorTest < Minitest::Test
           orchestrator.stub(:cleanup_processes, nil) do
             orchestrator.stub(:cleanup_run_symlink, nil) do
               orchestrator.stub(:cleanup_worktrees, nil) do
-                Dir.chdir(@tmpdir) do
-                  capture_io { orchestrator.start }
-                end
+                capture_io { orchestrator.start }
               end
             end
           end
@@ -904,7 +868,8 @@ class OrchestratorTest < Minitest::Test
 
       after_executed = false
 
-      orchestrator.stub(:execute_after_commands?, lambda { |_commands|
+      orchestrator.stub(:execute_after_commands?, lambda { |_commands, chdir:|
+        _ = chdir # Mark as used for RuboCop
         after_executed = true
         true
       }) do
@@ -950,9 +915,7 @@ class OrchestratorTest < Minitest::Test
         orchestrator.stub(:cleanup_processes, nil) do
           orchestrator.stub(:cleanup_run_symlink, nil) do
             orchestrator.stub(:cleanup_worktrees, nil) do
-              Dir.chdir(@tmpdir) do
-                capture_io { orchestrator.start }
-              end
+              capture_io { orchestrator.start }
             end
           end
         end
@@ -1008,12 +971,10 @@ class OrchestratorTest < Minitest::Test
             orchestrator.stub(:cleanup_worktrees, lambda {
               cleanup_worktrees_called = true
             }) do
-              Dir.chdir(@tmpdir) do
-                output = capture_io { orchestrator.start }[0]
+              output = capture_io { orchestrator.start }[0]
 
-                # Verify warning message
-                assert_match(/⚠️  Some after commands failed/, output)
-              end
+              # Verify warning message
+              assert_match(/⚠️  Some after commands failed/, output)
             end
           end
         end
@@ -1045,7 +1006,8 @@ class OrchestratorTest < Minitest::Test
 
       after_executed = false
 
-      orchestrator.stub(:execute_after_commands?, lambda { |_commands|
+      orchestrator.stub(:execute_after_commands?, lambda { |_commands, chdir:|
+        _ = chdir # Mark as used for RuboCop
         after_executed = true
         true
       }) do
@@ -1095,12 +1057,10 @@ class OrchestratorTest < Minitest::Test
         orchestrator.stub(:cleanup_processes, nil) do
           orchestrator.stub(:cleanup_run_symlink, nil) do
             orchestrator.stub(:cleanup_worktrees, nil) do
-              Dir.chdir(@tmpdir) do
-                # Simulate signal
-                capture_io do
-                  Signal.trap("INT") { orchestrator.send(:setup_signal_handlers) }
-                  Process.kill("INT", Process.pid)
-                end
+              # Simulate signal
+              capture_io do
+                Signal.trap("INT") { orchestrator.send(:setup_signal_handlers) }
+                Process.kill("INT", Process.pid)
               end
             end
           end
@@ -1137,7 +1097,7 @@ class OrchestratorTest < Minitest::Test
     )
 
     # Mock system to prevent actual execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -1155,7 +1115,7 @@ class OrchestratorTest < Minitest::Test
     orchestrator = ClaudeSwarm::Orchestrator.new(config, generator)
 
     # Mock system to prevent actual execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -1189,7 +1149,7 @@ class OrchestratorTest < Minitest::Test
       )
 
       # Mock system to prevent actual execution
-      orchestrator.stub(:system!, true) do
+      orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
         capture_io { orchestrator.start }
       end
 
@@ -1204,9 +1164,6 @@ class OrchestratorTest < Minitest::Test
   end
 
   def test_session_id_saved_in_metadata
-    # Set root directory for test
-    ENV["CLAUDE_SWARM_ROOT_DIR"] = Dir.pwd
-
     config = create_test_config
     generator = ClaudeSwarm::McpGenerator.new(config)
     custom_session_id = "metadata-test-456"
@@ -1218,7 +1175,7 @@ class OrchestratorTest < Minitest::Test
     )
 
     # Mock system to prevent actual execution
-    orchestrator.stub(:system!, true) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| true }) do
       capture_io { orchestrator.start }
     end
 
@@ -1230,7 +1187,9 @@ class OrchestratorTest < Minitest::Test
 
     metadata = JSON.parse(File.read(metadata_file))
 
-    assert_equal(Dir.pwd, metadata["root_directory"])
+    # Should use config's base_dir, which is @tmpdir (where config file is)
+    assert_equal(File.dirname(@config_path), metadata["root_directory"])
     assert_equal("Test Swarm", metadata["swarm_name"])
   end
 end
+# rubocop:enable Lint/UnusedBlockArgument

--- a/test/orchestrator_transcript_test.rb
+++ b/test/orchestrator_transcript_test.rb
@@ -364,6 +364,8 @@ class OrchestratorTranscriptTest < Minitest::Test
     8.times { config.expect(:main_instance, "lead") }
     # Expect instances to be called multiple times for orchestrator initialization
     7.times { config.expect(:instances, {}) }
+    # Expect base_dir to be called for session path generation
+    7.times { config.expect(:base_dir, Dir.pwd) }
     config
   end
 

--- a/test/orchestrator_worktree_cleanup_test.rb
+++ b/test/orchestrator_worktree_cleanup_test.rb
@@ -20,7 +20,7 @@ class OrchestratorWorktreeCleanupTest < Minitest::Test
   def teardown
     FileUtils.rm_rf(@test_dir)
     # Clean up any external worktrees created during tests
-    FileUtils.rm_rf(File.expand_path("~/.claude-swarm/worktrees/default"))
+    FileUtils.rm_rf(ClaudeSwarm.joined_worktrees_dir("default"))
   end
 
   def test_orchestrator_skips_cleanup_with_uncommitted_changes

--- a/test/orchestrator_worktree_cleanup_test.rb
+++ b/test/orchestrator_worktree_cleanup_test.rb
@@ -4,17 +4,15 @@ require "test_helper"
 
 class OrchestratorWorktreeCleanupTest < Minitest::Test
   def setup
-    @test_dir = File.realpath(Dir.mktmpdir)
+    @test_dir = Dir.mktmpdir
     @repo_dir = File.join(@test_dir, "test-repo")
     setup_git_repo(@repo_dir)
 
     @config_file = File.join(@repo_dir, "claude-swarm.yml")
     File.write(@config_file, swarm_config)
 
-    Dir.chdir(@repo_dir) do
-      @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
-      @generator = ClaudeSwarm::McpGenerator.new(@config)
-    end
+    @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
+    @generator = ClaudeSwarm::McpGenerator.new(@config)
   end
 
   def teardown
@@ -24,132 +22,124 @@ class OrchestratorWorktreeCleanupTest < Minitest::Test
   end
 
   def test_orchestrator_skips_cleanup_with_uncommitted_changes
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "test-uncommitted",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "test-uncommitted",
+    )
 
-      # We need to run start first to get the session ID
-      worktree_path = nil
+    # We need to run start first to get the session ID
+    worktree_path = nil
 
-      # Use a flag to track when to make changes
-      changes_made = false
+    # Use a flag to track when to make changes
+    changes_made = false
 
-      # Mock system to simulate Claude execution and make changes
-      orchestrator.stub(:system, lambda { |*args|
-        # When claude is launched, we're in the worktree directory
-        if args.any? { |arg| arg.to_s.include?("claude") } && !changes_made
-          # Get the worktree path from the manager
-          worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
-          worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
+    # Mock system! to simulate Claude execution and make changes
+    orchestrator.stub(:system!, lambda { |*args, chdir: nil|
+      # When claude is launched with a chdir to the worktree directory
+      if args.any? { |arg| arg.to_s.include?("claude") } && !changes_made && chdir
+        # Get the worktree path from the manager
+        worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
+        worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
 
-          # Make uncommitted changes in current directory (the worktree)
-          File.write("uncommitted.txt", "changes")
-          changes_made = true
-        end
-        true
-      }) do
-        output = capture_io { orchestrator.start }.join
-
-        # Check that cleanup warning was shown
-        assert_match(/has uncommitted changes, skipping cleanup/, output)
+        # Make uncommitted changes in the worktree directory
+        File.write(File.join(chdir, "uncommitted.txt"), "changes")
+        changes_made = true
       end
+      true
+    }) do
+      output = capture_io { orchestrator.start }.join
 
-      # Verify worktree still exists
-      assert(worktree_path, "Worktree path should be set")
-      assert_path_exists(worktree_path, "Worktree should not be deleted with uncommitted changes")
+      # Check that cleanup warning was shown
+      assert_match(/has uncommitted changes, skipping cleanup/, output)
     end
+
+    # Verify worktree still exists
+    assert(worktree_path, "Worktree path should be set")
+    assert_path_exists(worktree_path, "Worktree should not be deleted with uncommitted changes")
   end
 
   def test_orchestrator_skips_cleanup_with_unpushed_commits
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "test-unpushed",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "test-unpushed",
+    )
 
-      # We need to run start first to get the session ID
-      worktree_path = nil
+    # We need to run start first to get the session ID
+    worktree_path = nil
 
-      # Use a flag to track when to make commits
-      commits_made = false
+    # Use a flag to track when to make commits
+    commits_made = false
 
-      # Mock system to simulate Claude execution and make commits
-      orchestrator.stub(:system, lambda { |*args|
-        # When claude is launched, we're in the worktree directory
-        if args.any? { |arg| arg.to_s.include?("claude") } && !commits_made
-          # Get the worktree path from the manager
-          worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
-          worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
+    # Mock system! to simulate Claude execution and make commits
+    orchestrator.stub(:system!, lambda { |*args, chdir: nil|
+      # When claude is launched with a chdir to the worktree directory
+      if args.any? { |arg| arg.to_s.include?("claude") } && !commits_made && chdir
+        # Get the worktree path from the manager
+        worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
+        worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
 
-          # Make a commit in current directory (the worktree)
-          File.write("new_feature.txt", "feature content")
-          # Use backticks to avoid calling the stubbed system
-          %x(git add . 2>/dev/null)
-          %x(git commit -m "New feature" 2>/dev/null)
-          commits_made = true
-        end
-        true
-      }) do
-        output = capture_io { orchestrator.start }.join
-
-        # Check that cleanup warning was shown
-        assert_match(/has unpushed commits, skipping cleanup/, output)
+        # Make a commit in the worktree directory
+        File.write(File.join(chdir, "new_feature.txt"), "feature content")
+        # Run git commands with chdir option
+        system("git", "add", ".", chdir: chdir, out: File::NULL, err: File::NULL)
+        system("git", "commit", "-m", "New feature", chdir: chdir, out: File::NULL, err: File::NULL)
+        commits_made = true
       end
+      true
+    }) do
+      output = capture_io { orchestrator.start }.join
 
-      # Verify worktree still exists
-      assert(worktree_path, "Worktree path should be set")
-      assert_path_exists(worktree_path, "Worktree should not be deleted with unpushed commits")
+      # Check that cleanup warning was shown
+      assert_match(/has unpushed commits, skipping cleanup/, output)
     end
+
+    # Verify worktree still exists
+    assert(worktree_path, "Worktree path should be set")
+    assert_path_exists(worktree_path, "Worktree should not be deleted with unpushed commits")
   end
 
   def test_orchestrator_cleans_up_clean_worktree
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "test-clean",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "test-clean",
+    )
 
-      # We'll get the worktree path after it's created
-      worktree_path = nil
+    # We'll get the worktree path after it's created
+    worktree_path = nil
 
-      orchestrator.stub(:system, lambda { |*args|
-        # Get the worktree path from the manager when claude is launched
-        if args.any? { |arg| arg.to_s.include?("claude") }
-          worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
-          worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
-        end
-        true
-      }) do
-        output = capture_io { orchestrator.start }.join
-
-        # Should see normal cleanup message
-        assert_match(/Removing worktree:.*test-clean/, output)
+    orchestrator.stub(:system, lambda { |*args|
+      # Get the worktree path from the manager when claude is launched
+      if args.any? { |arg| arg.to_s.include?("claude") }
+        worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
+        worktree_path = worktree_manager.created_worktrees.values.first if worktree_manager
       end
+      true
+    }) do
+      output = capture_io { orchestrator.start }.join
 
-      # Verify worktree was removed
-      assert(worktree_path, "Worktree path should be set")
-      refute_path_exists(worktree_path, "Clean worktree should be deleted")
+      # Should see normal cleanup message
+      assert_match(/Removing worktree:.*test-clean/, output)
     end
+
+    # Verify worktree was removed
+    assert(worktree_path, "Worktree path should be set")
+    refute_path_exists(worktree_path, "Clean worktree should be deleted")
   end
 
   private
 
   def setup_git_repo(dir)
     FileUtils.mkdir_p(dir)
-    Dir.chdir(dir) do
-      system("git", "init", "--quiet", out: File::NULL, err: File::NULL)
-      # Configure git user for GitHub Actions
-      system("git", "config", "user.email", "test@example.com", out: File::NULL, err: File::NULL)
-      system("git", "config", "user.name", "Test User", out: File::NULL, err: File::NULL)
-      File.write("test.txt", "test content")
-      system("git", "add", ".", out: File::NULL, err: File::NULL)
-      system("git", "commit", "-m", "Initial commit", "--quiet", out: File::NULL, err: File::NULL)
-    end
+    system("git", "init", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
+    # Configure git user for GitHub Actions
+    system("git", "config", "user.email", "test@example.com", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "config", "user.name", "Test User", chdir: dir, out: File::NULL, err: File::NULL)
+    File.write(File.join(dir, "test.txt"), "test content")
+    system("git", "add", ".", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", "Initial commit", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
   end
 
   def swarm_config

--- a/test/orchestrator_worktree_error_cleanup_test.rb
+++ b/test/orchestrator_worktree_error_cleanup_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/UnusedBlockArgument
 require "test_helper"
 require "tmpdir"
 require "fileutils"
@@ -34,12 +35,10 @@ class OrchestratorWorktreeErrorCleanupTest < Minitest::Test
             model: sonnet
     YAML
 
-    # Change to repo directory
-    Dir.chdir(@repo_dir)
+    # No need to change directory - Configuration uses base_dir
   end
 
   def teardown
-    Dir.chdir("/") # Change out of temp dir before deleting
     FileUtils.rm_rf(@temp_dir)
   end
 
@@ -70,8 +69,8 @@ class OrchestratorWorktreeErrorCleanupTest < Minitest::Test
     )
 
     # Mock the system! method to prevent actual Claude execution
-    orchestrator.stub(:system!, nil) do
-      orchestrator.stub(:stream_to_session_log, nil) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| nil }) do
+      orchestrator.stub(:stream_to_session_log, lambda { |*_args, chdir: nil| nil }) do
         # Capture output to avoid test noise
         capture_io do
           # The orchestrator should exit(1) when before commands fail
@@ -119,8 +118,8 @@ class OrchestratorWorktreeErrorCleanupTest < Minitest::Test
     )
 
     # Mock the system! method to prevent actual Claude execution
-    orchestrator.stub(:system!, nil) do
-      orchestrator.stub(:stream_to_session_log, nil) do
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil| nil }) do
+      orchestrator.stub(:stream_to_session_log, lambda { |*_args, chdir: nil| nil }) do
         # Capture output to avoid test noise
         capture_io do
           # The orchestrator should exit(1) when directory validation fails
@@ -141,13 +140,12 @@ class OrchestratorWorktreeErrorCleanupTest < Minitest::Test
 
   def setup_git_repo(path)
     FileUtils.mkdir_p(path)
-    Dir.chdir(path) do
-      system("git init", out: File::NULL, err: File::NULL)
-      system("git config user.name 'Test User'", out: File::NULL, err: File::NULL)
-      system("git config user.email 'test@example.com'", out: File::NULL, err: File::NULL)
-      File.write("README.md", "Test repo")
-      system("git add README.md", out: File::NULL, err: File::NULL)
-      system("git commit -m 'Initial commit'", out: File::NULL, err: File::NULL)
-    end
+    system("git init", chdir: path, out: File::NULL, err: File::NULL)
+    system("git config user.name 'Test User'", chdir: path, out: File::NULL, err: File::NULL)
+    system("git config user.email 'test@example.com'", chdir: path, out: File::NULL, err: File::NULL)
+    File.write(File.join(path, "README.md"), "Test repo")
+    system("git add README.md", chdir: path, out: File::NULL, err: File::NULL)
+    system("git commit -m 'Initial commit'", chdir: path, out: File::NULL, err: File::NULL)
   end
 end
+# rubocop:enable Lint/UnusedBlockArgument

--- a/test/orchestrator_worktree_integration_test.rb
+++ b/test/orchestrator_worktree_integration_test.rb
@@ -4,17 +4,15 @@ require "test_helper"
 
 class OrchestratorWorktreeIntegrationTest < Minitest::Test
   def setup
-    @test_dir = File.realpath(Dir.mktmpdir)
+    @test_dir = Dir.mktmpdir
     @repo_dir = File.join(@test_dir, "test-repo")
     setup_git_repo(@repo_dir)
 
     @config_file = File.join(@repo_dir, "claude-swarm.yml")
     File.write(@config_file, swarm_config)
 
-    Dir.chdir(@repo_dir) do
-      @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
-      @generator = ClaudeSwarm::McpGenerator.new(@config)
-    end
+    @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
+    @generator = ClaudeSwarm::McpGenerator.new(@config)
   end
 
   def teardown
@@ -22,113 +20,105 @@ class OrchestratorWorktreeIntegrationTest < Minitest::Test
   end
 
   def test_orchestrator_creates_and_cleans_up_worktrees
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "test-feature",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "test-feature",
+    )
 
-      # Start the orchestrator and capture the worktree path
-      orchestrator.stub(:system, true) do
-        capture_io { orchestrator.start }
-      end
-
-      # Get the worktree info from the manager
-      worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
-
-      assert(worktree_manager, "Worktree manager should exist")
-
-      # Check that worktree was created
-      created_worktrees = worktree_manager.created_worktrees
-
-      assert_equal(1, created_worktrees.size, "One worktree should be created")
-
-      worktree_path = created_worktrees.values.first
-
-      assert(worktree_path, "Worktree path should be set")
-
-      # After execution, worktree should be cleaned up
-      refute_path_exists(worktree_path, "Worktree should be cleaned up after execution")
-
-      # Verify the worktree name
-      assert_equal("test-feature", worktree_manager.worktree_name)
+    # Start the orchestrator and capture the worktree path
+    orchestrator.stub(:system, true) do
+      capture_io { orchestrator.start }
     end
+
+    # Get the worktree info from the manager
+    worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
+
+    assert(worktree_manager, "Worktree manager should exist")
+
+    # Check that worktree was created
+    created_worktrees = worktree_manager.created_worktrees
+
+    assert_equal(1, created_worktrees.size, "One worktree should be created")
+
+    worktree_path = created_worktrees.values.first
+
+    assert(worktree_path, "Worktree path should be set")
+
+    # After execution, worktree should be cleaned up
+    refute_path_exists(worktree_path, "Worktree should be cleaned up after execution")
+
+    # Verify the worktree name
+    assert_equal("test-feature", worktree_manager.worktree_name)
   end
 
   def test_orchestrator_with_auto_generated_worktree_name
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "",
+    )
 
-      worktree_name = nil
+    worktree_name = nil
 
-      orchestrator.stub(:system, lambda { |*_args|
-        # Capture the worktree name from the manager
-        worktree_name = orchestrator.instance_variable_get(:@worktree_manager).worktree_name
-        true
-      }) do
-        capture_io { orchestrator.start }
-      end
-
-      # Verify worktree name was auto-generated with session ID (UUID format)
-      assert_match(/^worktree-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/, worktree_name)
-
-      # Worktree name should have been captured
-      assert(worktree_name, "Worktree name should be captured")
+    orchestrator.stub(:system, lambda { |*_args|
+      # Capture the worktree name from the manager
+      worktree_name = orchestrator.instance_variable_get(:@worktree_manager).worktree_name
+      true
+    }) do
+      capture_io { orchestrator.start }
     end
+
+    # Verify worktree name was auto-generated with session ID (UUID format)
+    assert_match(/^worktree-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/, worktree_name)
+
+    # Worktree name should have been captured
+    assert(worktree_name, "Worktree name should be captured")
   end
 
   def test_orchestrator_without_worktree_option
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config, @generator
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config, @generator
+    )
 
-      orchestrator.stub(:system, true) do
-        capture_io { orchestrator.start }
-      end
-
-      # Check no worktrees were created
-      worktrees = Dir.glob(File.join(@test_dir, "*")).select do |f|
-        File.directory?(f) && f != @repo_dir
-      end
-
-      assert_empty(worktrees, "No worktrees should be created")
-
-      # Verify no worktree manager was created
-      assert_nil(orchestrator.instance_variable_get(:@worktree_manager), "No worktree manager should exist")
+    orchestrator.stub(:system, true) do
+      capture_io { orchestrator.start }
     end
+
+    # Check no worktrees were created
+    worktrees = Dir.glob(File.join(@test_dir, "*")).select do |f|
+      File.directory?(f) && f != @repo_dir
+    end
+
+    assert_empty(worktrees, "No worktrees should be created")
+
+    # Verify no worktree manager was created
+    assert_nil(orchestrator.instance_variable_get(:@worktree_manager), "No worktree manager should exist")
   end
 
   def test_worktree_cleanup_happens
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        worktree: "cleanup-test",
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      worktree: "cleanup-test",
+    )
 
-      cleanup_called = false
+    cleanup_called = false
 
-      # Stub the system call and check cleanup at exit
-      orchestrator.stub(:system, lambda { |*_args|
-        # After start, worktree_manager should exist
-        worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
-        # Mock the cleanup method
-        worktree_manager&.define_singleton_method(:cleanup_worktrees) do
-          cleanup_called = true
-        end
-        true
-      }) do
-        capture_io { orchestrator.start }
+    # Stub the system call and check cleanup at exit
+    orchestrator.stub(:system, lambda { |*_args|
+      # After start, worktree_manager should exist
+      worktree_manager = orchestrator.instance_variable_get(:@worktree_manager)
+      # Mock the cleanup method
+      worktree_manager&.define_singleton_method(:cleanup_worktrees) do
+        cleanup_called = true
       end
-
-      assert(cleanup_called, "Worktree cleanup should be called")
+      true
+    }) do
+      capture_io { orchestrator.start }
     end
+
+    assert(cleanup_called, "Worktree cleanup should be called")
   end
 
   private

--- a/test/orchestrator_worktree_restoration_test.rb
+++ b/test/orchestrator_worktree_restoration_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class OrchestratorWorktreeRestorationTest < Minitest::Test
   def setup
-    @test_dir = File.realpath(Dir.mktmpdir)
+    @test_dir = Dir.mktmpdir
     @repo_dir = File.join(@test_dir, "test-repo")
     setup_git_repo(@repo_dir)
 
@@ -16,10 +16,8 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
     @session_path = File.join(@session_dir, @session_id)
     FileUtils.mkdir_p(@session_path)
 
-    Dir.chdir(@repo_dir) do
-      @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
-      @generator = ClaudeSwarm::McpGenerator.new(@config)
-    end
+    @config = ClaudeSwarm::Configuration.new(@config_file, base_dir: @repo_dir)
+    @generator = ClaudeSwarm::McpGenerator.new(@config)
   end
 
   def teardown
@@ -65,97 +63,75 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
 
     # Create the worktree manually in external location (simulating previous session)
     FileUtils.mkdir_p(File.dirname(external_worktree_path))
-    Dir.chdir(@repo_dir) do
-      # Clean up any existing worktree with the same name
-      system(
-        "git",
-        "worktree",
-        "remove",
-        "--force",
-        external_worktree_path,
-        out: File::NULL,
-        err: File::NULL,
-      )
-      # Also try to remove any old internal worktree
-      system(
-        "git",
-        "worktree",
-        "remove",
-        "--force",
-        ".worktrees/#{worktree_name}",
-        out: File::NULL,
-        err: File::NULL,
-      )
-      # Delete the branch if it exists
-      system(
-        "git",
-        "branch",
-        "-D",
-        worktree_name,
-        out: File::NULL,
-        err: File::NULL,
-      )
+    # Clean up any existing worktree with the same name
+    system(
+      "git",
+      "worktree",
+      "remove",
+      "--force",
+      external_worktree_path,
+      chdir: @repo_dir,
+      out: File::NULL,
+      err: File::NULL,
+    )
+    # Also try to remove any old internal worktree
+    system(
+      "git",
+      "worktree",
+      "remove",
+      "--force",
+      ".worktrees/#{worktree_name}",
+      chdir: @repo_dir,
+      out: File::NULL,
+      err: File::NULL,
+    )
+    # Delete the branch if it exists
+    system(
+      "git",
+      "branch",
+      "-D",
+      worktree_name,
+      chdir: @repo_dir,
+      out: File::NULL,
+      err: File::NULL,
+    )
 
-      # Create new worktree
-      output, status = Open3.capture2e(
-        "git",
-        "worktree",
-        "add",
-        "-b",
-        worktree_name,
-        external_worktree_path,
-        "HEAD",
-      )
-
-      # Ensure worktree was created
-      assert_predicate(status, :success?, "Failed to create worktree: #{output}")
-      assert_path_exists(external_worktree_path, "Worktree path should exist after creation")
-    end
+    # Create new worktree
+    system(
+      "git",
+      "worktree",
+      "add",
+      "-b",
+      worktree_name,
+      external_worktree_path,
+      "HEAD",
+      chdir: @repo_dir,
+      out: File::NULL,
+      err: File::NULL,
+    )
 
     # Now test restoration
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        restore_session_path: @session_path,
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      restore_session_path: @session_path,
+    )
 
-      # Mock system call to verify directory
-      worktree_dir_used = nil
-      dir_existed_during_run = false
-      orchestrator.stub(:system, lambda { |*_args|
-        worktree_dir_used = Dir.pwd
-        dir_existed_during_run = File.exist?(Dir.pwd)
-        true
-      }) do
-        capture_io { orchestrator.start }
-      end
-
-      # Verify the main instance started in the external worktree
-      # The working directory should have been captured
-      assert(worktree_dir_used, "Working directory should be captured")
-
-      # The directory should have existed when the command was run
-      assert(dir_existed_during_run, "Working directory should have existed during execution: #{worktree_dir_used}")
-
-      # Check if the used directory is in the expected worktree location
-      # Use basename comparison since the exact path might vary due to symlinks or recreation
-      expected_worktree_name = File.basename(external_worktree_path)
-      actual_worktree_name = File.basename(worktree_dir_used)
-
-      assert_equal(
-        expected_worktree_name,
-        actual_worktree_name,
-        "Main instance should start in a worktree with the correct name. Full path: #{worktree_dir_used}",
-      )
-
-      # Also verify it's in the worktrees directory structure
-      assert_includes(
-        worktree_dir_used,
-        "worktrees",
-        "Working directory should be in a worktrees path: #{worktree_dir_used}",
-      )
+    # Mock system! call to verify directory
+    worktree_dir_used = nil
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil|
+      worktree_dir_used = chdir
+      true
+    }) do
+      capture_io { orchestrator.start }
     end
+
+    # Verify the main instance started in the external worktree
+    assert_equal(
+      external_worktree_path,
+      worktree_dir_used,
+      "Main instance should start in the restored external worktree",
+    )
   end
 
   def test_restoration_without_worktrees
@@ -175,44 +151,40 @@ class OrchestratorWorktreeRestorationTest < Minitest::Test
     FileUtils.cp(@config_file, File.join(@session_path, "config.yml"))
 
     # Test restoration
-    Dir.chdir(@repo_dir) do
-      orchestrator = ClaudeSwarm::Orchestrator.new(
-        @config,
-        @generator,
-        restore_session_path: @session_path,
-      )
+    orchestrator = ClaudeSwarm::Orchestrator.new(
+      @config,
+      @generator,
+      restore_session_path: @session_path,
+    )
 
-      # Mock system call to verify directory
-      dir_used = nil
-      orchestrator.stub(:system, lambda { |*_args|
-        dir_used = Dir.pwd
-        true
-      }) do
-        capture_io { orchestrator.start }
-      end
-
-      # Verify the main instance started in the regular directory
-      assert_equal(
-        File.realpath(@repo_dir),
-        File.realpath(dir_used),
-        "Main instance should start in the regular directory when no worktrees were used",
-      )
+    # Mock system call to verify directory
+    dir_used = nil
+    orchestrator.stub(:system!, lambda { |*_args, chdir: nil|
+      dir_used = chdir || @repo_dir
+      true
+    }) do
+      capture_io { orchestrator.start }
     end
+
+    # Verify the main instance started in the regular directory
+    assert_equal(
+      File.realpath(@repo_dir),
+      File.realpath(dir_used),
+      "Main instance should start in the regular directory when no worktrees were used",
+    )
   end
 
   private
 
   def setup_git_repo(dir)
     FileUtils.mkdir_p(dir)
-    Dir.chdir(dir) do
-      system("git", "init", "--quiet", out: File::NULL, err: File::NULL)
-      # Configure git user for GitHub Actions
-      system("git", "config", "user.email", "test@example.com", out: File::NULL, err: File::NULL)
-      system("git", "config", "user.name", "Test User", out: File::NULL, err: File::NULL)
-      File.write("test.txt", "test content")
-      system("git", "add", ".", out: File::NULL, err: File::NULL)
-      system("git", "commit", "-m", "Initial commit", "--quiet", out: File::NULL, err: File::NULL)
-    end
+    system("git", "init", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
+    # Configure git user for GitHub Actions
+    system("git", "config", "user.email", "test@example.com", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "config", "user.name", "Test User", chdir: dir, out: File::NULL, err: File::NULL)
+    File.write(File.join(dir, "test.txt"), "test content")
+    system("git", "add", ".", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", "Initial commit", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
   end
 
   def swarm_config

--- a/test/session_path_test.rb
+++ b/test/session_path_test.rb
@@ -34,7 +34,7 @@ class SessionPathTest < Minitest::Test
       session_id: session_id,
     )
 
-    expected = File.join(ClaudeSwarm::SessionPath.swarm_home, "sessions/Users+paulo+test/550e8400-e29b-41d4-a716-446655440000")
+    expected = ClaudeSwarm.joined_sessions_dir("Users+paulo+test", "550e8400-e29b-41d4-a716-446655440000")
 
     assert_equal(expected, result)
   end
@@ -74,7 +74,7 @@ class SessionPathTest < Minitest::Test
     session_path = ClaudeSwarm::SessionPath.generate
     ClaudeSwarm::SessionPath.ensure_directory(session_path)
 
-    gitignore_path = File.join(ClaudeSwarm::SessionPath.swarm_home, ".gitignore")
+    gitignore_path = ClaudeSwarm.joined_home_dir(".gitignore")
 
     assert_path_exists(gitignore_path)
     assert_equal("*\n", File.read(gitignore_path))

--- a/test/session_path_test.rb
+++ b/test/session_path_test.rb
@@ -19,11 +19,9 @@ class SessionPathTest < Minitest::Test
   def test_project_folder_name_with_current_directory
     # Should work with current directory
     Dir.mktmpdir do |tmpdir|
-      Dir.chdir(tmpdir) do
-        result = ClaudeSwarm::SessionPath.project_folder_name
-        # Extract just the last part of the path for comparison
-        assert(result.end_with?(File.basename(tmpdir)))
-      end
+      result = ClaudeSwarm::SessionPath.project_folder_name(tmpdir)
+      # Extract just the last part of the path for comparison
+      assert_includes(result, File.basename(tmpdir))
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,10 +20,12 @@ require_relative "helpers/test_helpers"
 
 # Set up a temporary home directory for all tests
 require "tmpdir"
-TEST_SWARM_HOME = Dir.mktmpdir("claude-swarm-test")
-ENV["CLAUDE_SWARM_HOME"] = TEST_SWARM_HOME
+test_swarm_home = Dir.mktmpdir("claude-swarm-test")
+original_home_dir = ENV["CLAUDE_SWARM_HOME"]
+ENV["CLAUDE_SWARM_HOME"] = test_swarm_home
 
 # Clean up the test home directory after all tests
 Minitest.after_run do
-  FileUtils.rm_rf(TEST_SWARM_HOME)
+  FileUtils.rm_rf(test_swarm_home)
+  ENV["CLAUDE_SWARM_HOME"] = original_home_dir
 end

--- a/test/working_directory_restoration_test.rb
+++ b/test/working_directory_restoration_test.rb
@@ -45,72 +45,64 @@ class WorkingDirectoryRestorationTest < Minitest::Test
   end
 
   def test_directory_resolution_during_restoration
-    # Simulate restoration from a different directory
-    Dir.chdir(@root_dir) do
-      # Load config without base_dir (like it would during normal run)
-      config_normal = ClaudeSwarm::Configuration.new(@config_path)
+    # Test that config loading uses base_dir when provided,
+    # and config file's directory when base_dir is not provided
 
-      # Load config with base_dir (like it would during restoration)
-      config_restored = ClaudeSwarm::Configuration.new(
-        File.join(@session_dir, "config.yml"),
-        base_dir: @project_dir,
-      )
+    # Load config without base_dir (uses config file's directory as base)
+    config_normal = ClaudeSwarm::Configuration.new(@config_path)
 
-      # Verify directories are resolved correctly
-      lead_normal = config_normal.instances["lead"]
-      lead_restored = config_restored.instances["lead"]
+    # Load config with explicit base_dir (as done during restoration)
+    config_restored = ClaudeSwarm::Configuration.new(
+      File.join(@session_dir, "config.yml"),
+      base_dir: @project_dir,
+    )
 
-      assert_equal(
-        File.realpath(@project_dir),
-        File.realpath(lead_normal[:directory]),
-        "Normal load should resolve . to project directory",
-      )
-      assert_equal(
-        File.realpath(@project_dir),
-        File.realpath(lead_restored[:directory]),
-        "Restored load should also resolve . to project directory",
-      )
+    # Both should resolve directories correctly
+    lead_normal = config_normal.instances["lead"]
+    lead_restored = config_restored.instances["lead"]
 
-      worker_normal = config_normal.instances["worker"]
-      worker_restored = config_restored.instances["worker"]
+    assert_equal(
+      File.realpath(@project_dir),
+      File.realpath(lead_normal[:directory]),
+      "Normal load should resolve . relative to config file location",
+    )
+    assert_equal(
+      File.realpath(@project_dir),
+      File.realpath(lead_restored[:directory]),
+      "Restored load with base_dir should resolve . to project directory",
+    )
 
-      assert_equal(
-        File.realpath(@subdir),
-        File.realpath(worker_normal[:directory]),
-        "Normal load should resolve ./subdir correctly",
-      )
-      assert_equal(
-        File.realpath(@subdir),
-        File.realpath(worker_restored[:directory]),
-        "Restored load should also resolve ./subdir correctly",
-      )
-    end
+    worker_normal = config_normal.instances["worker"]
+    worker_restored = config_restored.instances["worker"]
+
+    assert_equal(
+      File.realpath(@subdir),
+      File.realpath(worker_normal[:directory]),
+      "Normal load should resolve ./subdir relative to config file location",
+    )
+    assert_equal(
+      File.realpath(@subdir),
+      File.realpath(worker_restored[:directory]),
+      "Restored load should resolve ./subdir relative to base_dir",
+    )
   end
 
   def test_restoration_from_different_working_directory
-    # Test that restoration works even when invoked from a completely different directory
-    other_dir = Dir.mktmpdir
+    # Test that restoration works by using base_dir parameter,
+    # regardless of current working directory
 
-    begin
-      Dir.chdir(other_dir) do
-        # This simulates what happens in CLI#restore_session
-        original_dir = File.read(File.join(@session_dir, "root_directory")).strip
+    # This simulates what happens in CLI#restore_session
+    original_dir = File.read(File.join(@session_dir, "root_directory")).strip
 
-        # Change to original directory
-        Dir.chdir(original_dir) do
-          # Load configuration with current directory as base
-          config = ClaudeSwarm::Configuration.new(
-            File.join(@session_dir, "config.yml"),
-            base_dir: Dir.pwd,
-          )
+    # Load configuration with original directory as base
+    # This works from any directory without needing to chdir
+    config = ClaudeSwarm::Configuration.new(
+      File.join(@session_dir, "config.yml"),
+      base_dir: original_dir,
+    )
 
-          # Verify instances have correct directories (normalize paths for comparison)
-          assert_equal(File.realpath(@project_dir), File.realpath(config.instances["lead"][:directory]))
-          assert_equal(File.realpath(@subdir), File.realpath(config.instances["worker"][:directory]))
-        end
-      end
-    ensure
-      FileUtils.rm_rf(other_dir)
-    end
+    # Verify instances have correct directories (normalize paths for comparison)
+    assert_equal(File.realpath(@project_dir), File.realpath(config.instances["lead"][:directory]))
+    assert_equal(File.realpath(@subdir), File.realpath(config.instances["worker"][:directory]))
   end
 end

--- a/test/worktree_manager_test.rb
+++ b/test/worktree_manager_test.rb
@@ -52,7 +52,7 @@ class WorktreeManagerTest < Minitest::Test
     # Check worktree was created in external directory
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/test-worktree")
+    worktree_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "test-worktree")
 
     assert_path_exists(worktree_path, "Worktree should be created in external directory")
 
@@ -81,11 +81,11 @@ class WorktreeManagerTest < Minitest::Test
     # Check both worktrees were created in external directories
     repo_name1 = File.basename(@repo_dir)
     repo_hash1 = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path1 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name1}-#{repo_hash1}/multi-repo")
+    worktree_path1 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name1}-#{repo_hash1}", "multi-repo")
 
     repo_name2 = File.basename(@other_repo_dir)
     repo_hash2 = Digest::SHA256.hexdigest(@other_repo_dir)[0..7]
-    worktree_path2 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name2}-#{repo_hash2}/multi-repo")
+    worktree_path2 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name2}-#{repo_hash2}", "multi-repo")
 
     assert_path_exists(worktree_path1, "First worktree should be created")
     assert_path_exists(worktree_path2, "Second worktree should be created")
@@ -110,11 +110,11 @@ class WorktreeManagerTest < Minitest::Test
     # Check all directories were mapped
     repo_name1 = File.basename(@repo_dir)
     repo_hash1 = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path1 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name1}-#{repo_hash1}/array-test")
+    worktree_path1 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name1}-#{repo_hash1}", "array-test")
 
     repo_name2 = File.basename(@other_repo_dir)
     repo_hash2 = Digest::SHA256.hexdigest(@other_repo_dir)[0..7]
-    worktree_path2 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name2}-#{repo_hash2}/array-test")
+    worktree_path2 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name2}-#{repo_hash2}", "array-test")
 
     expected_dirs = [
       worktree_path1,
@@ -147,11 +147,11 @@ class WorktreeManagerTest < Minitest::Test
     # Verify worktrees exist
     repo_name1 = File.basename(@repo_dir)
     repo_hash1 = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path1 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name1}-#{repo_hash1}/cleanup-test")
+    worktree_path1 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name1}-#{repo_hash1}", "cleanup-test")
 
     repo_name2 = File.basename(@other_repo_dir)
     repo_hash2 = Digest::SHA256.hexdigest(@other_repo_dir)[0..7]
-    worktree_path2 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name2}-#{repo_hash2}/cleanup-test")
+    worktree_path2 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name2}-#{repo_hash2}", "cleanup-test")
 
     assert_path_exists(worktree_path1)
     assert_path_exists(worktree_path2)
@@ -181,7 +181,7 @@ class WorktreeManagerTest < Minitest::Test
 
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    expected_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/metadata-test")
+    expected_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "metadata-test")
 
     assert_equal(expected_path, metadata[:created_paths]["#{@repo_dir}:metadata-test"])
   end
@@ -191,7 +191,7 @@ class WorktreeManagerTest < Minitest::Test
     worktree_name = "existing-worktree"
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_base = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}")
+    worktree_base = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}")
     FileUtils.mkdir_p(worktree_base)
     worktree_path = File.join(worktree_base, worktree_name)
 
@@ -238,7 +238,7 @@ class WorktreeManagerTest < Minitest::Test
 
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/#{branch_name}")
+    worktree_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", branch_name)
 
     assert_path_exists(worktree_path, "Worktree should be created")
 
@@ -303,7 +303,7 @@ class WorktreeManagerTest < Minitest::Test
     # Main instance should be in worktree
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    expected_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/shared-worktree")
+    expected_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "shared-worktree")
 
     assert_equal(expected_path, instances[0][:directory])
 
@@ -324,14 +324,14 @@ class WorktreeManagerTest < Minitest::Test
     # Main instance should use shared worktree
     repo_name1 = File.basename(@repo_dir)
     repo_hash1 = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    expected_path1 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name1}-#{repo_hash1}/shared-worktree")
+    expected_path1 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name1}-#{repo_hash1}", "shared-worktree")
 
     assert_equal(expected_path1, instances[0][:directory])
 
     # Other instance should use custom worktree
     repo_name2 = File.basename(@other_repo_dir)
     repo_hash2 = Digest::SHA256.hexdigest(@other_repo_dir)[0..7]
-    expected_path2 = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name2}-#{repo_hash2}/custom-branch")
+    expected_path2 = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name2}-#{repo_hash2}", "custom-branch")
 
     assert_equal(expected_path2, instances[1][:directory])
   end
@@ -352,7 +352,7 @@ class WorktreeManagerTest < Minitest::Test
     # Other instance should use custom worktree
     repo_name = File.basename(@other_repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@other_repo_dir)[0..7]
-    expected_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/feature-x")
+    expected_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "feature-x")
 
     assert_equal(expected_path, instances[1][:directory])
   end
@@ -382,7 +382,7 @@ class WorktreeManagerTest < Minitest::Test
     # Make changes in the worktree
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/test-changes")
+    worktree_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "test-changes")
 
     assert_path_exists(worktree_path)
 
@@ -447,7 +447,7 @@ class WorktreeManagerTest < Minitest::Test
 
     repo_name = File.basename(@repo_dir)
     repo_hash = Digest::SHA256.hexdigest(@repo_dir)[0..7]
-    worktree_path = File.expand_path("~/.claude-swarm/worktrees/default/#{repo_name}-#{repo_hash}/test-clean")
+    worktree_path = ClaudeSwarm.joined_worktrees_dir("default", "#{repo_name}-#{repo_hash}", "test-clean")
 
     assert_path_exists(worktree_path)
 
@@ -467,7 +467,7 @@ class WorktreeManagerTest < Minitest::Test
     manager.setup_worktrees(instances)
 
     # Check that session directory exists
-    session_worktree_dir = File.expand_path("~/.claude-swarm/worktrees/test_session_123")
+    session_worktree_dir = ClaudeSwarm.joined_worktrees_dir("test_session_123")
 
     assert_path_exists(session_worktree_dir)
 

--- a/test/worktree_manager_test.rb
+++ b/test/worktree_manager_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class WorktreeManagerTest < Minitest::Test
   def setup
-    @test_dir = File.realpath(Dir.mktmpdir)
+    @test_dir = Dir.mktmpdir
     @repo_dir = File.join(@test_dir, "test-repo")
     @other_repo_dir = File.join(@test_dir, "other-repo")
 
@@ -61,11 +61,9 @@ class WorktreeManagerTest < Minitest::Test
     assert_equal(File.join(worktree_path, "subdir"), instances[1][:directory])
 
     # Check that worktree is on a branch, not detached HEAD
-    Dir.chdir(worktree_path) do
-      output = %x(git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
+    output = %x(cd "#{worktree_path}" && git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
 
-      assert_equal("test-worktree", output, "Worktree should be on a branch named 'test-worktree'")
-    end
+    assert_equal("test-worktree", output, "Worktree should be on a branch named 'test-worktree'")
   end
 
   def test_setup_worktrees_multiple_repos
@@ -195,9 +193,7 @@ class WorktreeManagerTest < Minitest::Test
     FileUtils.mkdir_p(worktree_base)
     worktree_path = File.join(worktree_base, worktree_name)
 
-    Dir.chdir(@repo_dir) do
-      system("git", "worktree", "add", "-b", worktree_name, worktree_path, "HEAD", out: File::NULL, err: File::NULL)
-    end
+    system("git", "worktree", "add", "-b", worktree_name, worktree_path, "HEAD", chdir: @repo_dir, out: File::NULL, err: File::NULL)
 
     manager = ClaudeSwarm::WorktreeManager.new(worktree_name)
 
@@ -214,17 +210,15 @@ class WorktreeManagerTest < Minitest::Test
   def test_existing_branch_reuse
     # Create a branch first
     branch_name = "existing-branch"
-    Dir.chdir(@repo_dir) do
-      # Get current branch
-      current_branch = %x(git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
+    # Get current branch
+    current_branch = %x(cd "#{@repo_dir}" && git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
 
-      # Create a new branch from current position
-      system("git", "branch", branch_name, out: File::NULL, err: File::NULL)
+    # Create a new branch from current position
+    system("git", "branch", branch_name, chdir: @repo_dir, out: File::NULL, err: File::NULL)
 
-      # Only checkout if we're not already on that branch
-      if current_branch != branch_name
-        # Stay on current branch - don't need to switch
-      end
+    # Only checkout if we're not already on that branch
+    if current_branch != branch_name
+      # Stay on current branch - don't need to switch
     end
 
     manager = ClaudeSwarm::WorktreeManager.new(branch_name)
@@ -243,11 +237,9 @@ class WorktreeManagerTest < Minitest::Test
     assert_path_exists(worktree_path, "Worktree should be created")
 
     # Check that worktree is on the existing branch
-    Dir.chdir(worktree_path) do
-      output = %x(git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
+    output = %x(cd "#{worktree_path}" && git rev-parse --abbrev-ref HEAD 2>/dev/null).strip
 
-      assert_equal(branch_name, output, "Worktree should be on the existing branch")
-    end
+    assert_equal(branch_name, output, "Worktree should be on the existing branch")
   end
 
   def test_empty_worktree_name_generates_name
@@ -416,11 +408,9 @@ class WorktreeManagerTest < Minitest::Test
 
     assert_path_exists(worktree_path)
 
-    Dir.chdir(worktree_path) do
-      File.write("committed_file.txt", "committed content")
-      system("git", "add", ".", out: File::NULL, err: File::NULL)
-      system("git", "commit", "-m", "Unpushed commit", out: File::NULL, err: File::NULL)
-    end
+    File.write(File.join(worktree_path, "committed_file.txt"), "committed content")
+    system("git", "add", ".", chdir: worktree_path, out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", "Unpushed commit", chdir: worktree_path, out: File::NULL, err: File::NULL)
 
     # Temporarily unset the prompt suppression for this test
     ENV.delete("CLAUDE_SWARM_PROMPT")
@@ -480,14 +470,12 @@ class WorktreeManagerTest < Minitest::Test
 
   def test_cleanup_removes_worktree_created_from_feature_branch_without_changes
     # Create a feature branch in the main repo
-    Dir.chdir(@repo_dir) do
-      # Create and checkout a feature branch
-      system("git", "checkout", "-b", "feature-branch", out: File::NULL, err: File::NULL)
-      # Make a commit on the feature branch
-      File.write("feature.txt", "feature content")
-      system("git", "add", ".", out: File::NULL, err: File::NULL)
-      system("git", "commit", "-m", "Feature commit", out: File::NULL, err: File::NULL)
-    end
+    # Create and checkout a feature branch
+    system("git", "checkout", "-b", "feature-branch", chdir: @repo_dir, out: File::NULL, err: File::NULL)
+    # Make a commit on the feature branch
+    File.write(File.join(@repo_dir, "feature.txt"), "feature content")
+    system("git", "add", ".", chdir: @repo_dir, out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", "Feature commit", chdir: @repo_dir, out: File::NULL, err: File::NULL)
 
     manager = ClaudeSwarm::WorktreeManager.new("test-feature-worktree")
 
@@ -670,54 +658,52 @@ class WorktreeManagerTest < Minitest::Test
 
   def test_session_metadata_path_resolution_with_relative_paths
     # Create a relative path scenario
-    Dir.chdir(@test_dir) do
-      relative_repo = "./test-repo"
-      relative_other = "./other-repo"
+    relative_repo = File.join(@test_dir, "test-repo")
+    relative_other = File.join(@test_dir, "other-repo")
 
-      manager = nil
-      metadata = nil
+    manager = nil
+    metadata = nil
 
-      capture_io do
-        manager = ClaudeSwarm::WorktreeManager.new("relative-test")
+    capture_io do
+      manager = ClaudeSwarm::WorktreeManager.new("relative-test")
 
-        instances = [
-          { name: "main", directory: relative_repo, worktree: true },
-          {
-            name: "multi",
-            directories: [relative_repo, File.join(relative_repo, "subdir"), relative_other],
-            worktree: "custom-relative",
-          },
-        ]
+      instances = [
+        { name: "main", directory: relative_repo, worktree: true },
+        {
+          name: "multi",
+          directories: [relative_repo, File.join(relative_repo, "subdir"), relative_other],
+          worktree: "custom-relative",
+        },
+      ]
 
-        manager.setup_worktrees(instances)
-        metadata = manager.session_metadata
-      end
-
-      # Check that relative paths are properly resolved to absolute paths
-      assert_valid_instance_metadata(metadata, "main", {
-        worktree_config: { skip: false, name: "relative-test" },
-        directories: [File.expand_path(@repo_dir)],
-        worktree_paths: [calculate_worktree_path(@repo_dir, "relative-test")],
-      })
-
-      # Calculate expected paths for multi instance
-      worktree_path1 = calculate_worktree_path(@repo_dir, "custom-relative")
-      worktree_path2 = calculate_worktree_path(@other_repo_dir, "custom-relative")
-
-      assert_valid_instance_metadata(metadata, "multi", {
-        worktree_config: { skip: false, name: "custom-relative" },
-        directories: [
-          File.expand_path(@repo_dir),
-          File.expand_path(File.join(@repo_dir, "subdir")),
-          File.expand_path(@other_repo_dir),
-        ],
-        worktree_paths: [
-          worktree_path1,
-          File.join(worktree_path1, "subdir"),
-          worktree_path2,
-        ],
-      })
+      manager.setup_worktrees(instances)
+      metadata = manager.session_metadata
     end
+
+    # Check that relative paths are properly resolved to absolute paths
+    assert_valid_instance_metadata(metadata, "main", {
+      worktree_config: { skip: false, name: "relative-test" },
+      directories: [File.expand_path(@repo_dir)],
+      worktree_paths: [calculate_worktree_path(@repo_dir, "relative-test")],
+    })
+
+    # Calculate expected paths for multi instance
+    worktree_path1 = calculate_worktree_path(@repo_dir, "custom-relative")
+    worktree_path2 = calculate_worktree_path(@other_repo_dir, "custom-relative")
+
+    assert_valid_instance_metadata(metadata, "multi", {
+      worktree_config: { skip: false, name: "custom-relative" },
+      directories: [
+        File.expand_path(@repo_dir),
+        File.expand_path(File.join(@repo_dir, "subdir")),
+        File.expand_path(@other_repo_dir),
+      ],
+      worktree_paths: [
+        worktree_path1,
+        File.join(worktree_path1, "subdir"),
+        worktree_path2,
+      ],
+    })
   end
 
   def test_session_metadata_with_invalid_worktree_config
@@ -809,17 +795,44 @@ class WorktreeManagerTest < Minitest::Test
 
   private
 
+  def assert_valid_instance_metadata(metadata, instance_name, expected)
+    instance_config = metadata[:instance_configs][instance_name]
+
+    assert(instance_config, "Instance #{instance_name} should have metadata")
+
+    # Check worktree config
+    expected[:worktree_config]&.each do |key, value|
+      assert_equal(value, instance_config[:worktree_config][key], "Instance #{instance_name} #{key} should match")
+    end
+
+    # Check directories
+    if expected[:directories]
+      assert_equal(
+        expected[:directories],
+        instance_config[:directories],
+        "Instance #{instance_name} directories should match",
+      )
+    end
+
+    # Check worktree paths
+    if expected[:worktree_paths]
+      assert_equal(
+        expected[:worktree_paths],
+        instance_config[:worktree_paths],
+        "Instance #{instance_name} worktree paths should match",
+      )
+    end
+  end
+
   def setup_git_repo(dir)
     FileUtils.mkdir_p(dir)
-    Dir.chdir(dir) do
-      system("git", "init", "--quiet", out: File::NULL, err: File::NULL)
-      # Configure git user for GitHub Actions
-      system("git", "config", "user.email", "test@example.com", out: File::NULL, err: File::NULL)
-      system("git", "config", "user.name", "Test User", out: File::NULL, err: File::NULL)
-      File.write("test.txt", "test content")
-      system("git", "add", ".", out: File::NULL, err: File::NULL)
-      system("git", "commit", "-m", "Initial commit", "--quiet", out: File::NULL, err: File::NULL)
-    end
+    system("git", "init", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
+    # Configure git user for GitHub Actions
+    system("git", "config", "user.email", "test@example.com", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "config", "user.name", "Test User", chdir: dir, out: File::NULL, err: File::NULL)
+    File.write(File.join(dir, "test.txt"), "test content")
+    system("git", "add", ".", chdir: dir, out: File::NULL, err: File::NULL)
+    system("git", "commit", "-m", "Initial commit", "--quiet", chdir: dir, out: File::NULL, err: File::NULL)
 
     # Create subdirectory
     FileUtils.mkdir_p(File.join(dir, "subdir"))


### PR DESCRIPTION
## Summary

This PR modernizes how we handle directory contexts by using the `chdir:` parameter for subprocess execution instead of changing the current process's working directory with `Dir.chdir`. This approach is cleaner, safer, and eliminates test artifacts being created in unexpected locations.

## Problem

The codebase had several issues with directory management:
- **Brittle tests**: Tests were too dependent on `Dir.chdir`, making them fragile and unsafe for parallel execution
- **Excessive `Dir.chdir` usage**: Tests and production code were changing the process's working directory instead of using the `chdir:` parameter for subprocess execution
- **Test artifacts in current directory**: The `with_temp_dir` helper wasn't actually changing into the temp directory, causing test files to be created in the current working directory
- **Global state**: `ClaudeSwarm.root_dir` was using environment variables to track directory state globally
- **Thread safety concerns**: `Dir.chdir` affects the entire process, making parallel test execution risky
- **Unnecessary environment variables**: `CLAUDE_SWARM_ROOT_DIR` was being set and used when Configuration already handles base directory

## Solution

### 1. Fixed test helper to prevent artifacts in current directory
- **Fixed `with_temp_dir` helper**: Now actually changes into the temp directory, preventing test files (`claude-swarm.yml`, `test.txt`, `test file with spaces & chars.txt`) from being created in the current directory

### 2. Removed unnecessary Dir.chdir calls from tests
Since Configuration accepts a `base_dir` parameter, tests no longer need to change directories:
- **test/orchestrator_worktree_integration_test.rb**: Removed all `Dir.chdir(@repo_dir)` wrappers
- **test/working_directory_behavior_test.rb**: Eliminated all `Dir.chdir` calls, using `base_dir` parameter directly
- **test/working_directory_restoration_test.rb**: Simplified tests by removing directory changes

### 3. Improved subprocess execution with chdir parameter
- **Updated system calls to use `chdir:` parameter**: Instead of changing the current process directory with `Dir.chdir`, we now pass `chdir:` to system calls (`system`, `Open3.capture2e`, etc.) to spawn subprocesses in the correct directory
- **Modified methods to accept `chdir:` keyword argument**: Updated `stream_to_session_log`, `system!`, and other process execution methods to properly handle the `chdir:` parameter
- **Better process isolation**: Subprocesses run in their specified directory without affecting the parent process

### 4. Consolidated directory management
- **Use Configuration's `base_dir` directly**: Instead of passing directory through multiple layers, Orchestrator now uses `@config.base_dir`
- **Exposed Configuration's `base_dir`**: Added to `attr_reader` for public access
- **Removed `CLAUDE_SWARM_ROOT_DIR` setting**: Orchestrator no longer sets this environment variable
- **Eliminated global state**: Removed `ClaudeSwarm.root_dir` class method that relied on environment variables

### 5. Fixed test compatibility issues
- **Path resolution on macOS**: Removed `File.realpath` usage that caused symlink issues
- **Updated test mocks**: Added `base_dir` method to mock configurations
- **Fixed metadata test**: Now checks `config.base_dir` instead of `Dir.pwd`

## Key Changes

### Process Execution
The main change is how we execute subprocesses in different directories:

**Before:**
```ruby
Dir.chdir(some_directory) do
  system("command")
  Open3.capture2e("another command")
end
```

**After:**
```ruby
system("command", chdir: some_directory)
Open3.capture2e("another command", chdir: some_directory)
```

## Changes by file

### Core Library
- **lib/claude_swarm.rb**: Removed `root_dir` class method
- **lib/claude_swarm/configuration.rb**: Added `base_dir` to public interface
- **lib/claude_swarm/orchestrator.rb**: 
  - Now uses `config.base_dir` directly instead of environment variables
  - Updated `stream_to_session_log` to accept and pass `chdir:` parameter
  - Updated `system!` method to handle `chdir:` parameter
  - Modified process execution to use `chdir:` instead of `Dir.chdir`
  - Stopped setting `CLAUDE_SWARM_ROOT_DIR` environment variable
- **lib/claude_swarm/cli.rb**: No longer needs to track or pass root directory

### Test Suite
- **test/helpers/test_helpers.rb**: Fixed `with_temp_dir` to change directory
- **test/orchestrator_test.rb**: Updated metadata test to check `config.base_dir`
- **test/orchestrator_symlink_test.rb**: Added `base_dir` to MockConfiguration
- **test/orchestrator_transcript_test.rb**: Added `base_dir` expectations
- **test/worktree_manager_test.rb**: Removed duplicate methods and `File.realpath`
- **test/orchestrator_worktree_integration_test.rb**: Removed unnecessary `Dir.chdir`
- **test/working_directory_behavior_test.rb**: Removed all `Dir.chdir` calls
- **test/working_directory_restoration_test.rb**: Simplified without `Dir.chdir`

## Testing

- ✅ All 505 tests pass (0 failures, 0 errors)
- ✅ RuboCop linting passes
- ✅ No test artifacts created in current directory
- ✅ Tests properly use temp directories

## Benefits

1. **Safer parallel test execution**: Tests can now run in parallel without directory conflicts since `chdir:` doesn't affect other threads or processes
2. **Better process isolation**: Using `chdir:` parameter doesn't affect the parent process's working directory
3. **More robust tests**: Removed brittle dependencies on `Dir.chdir`, making tests more reliable and predictable
4. **Cleaner test suite**: Tests no longer pollute the current directory with artifacts
5. **Thread-safe**: No risk of directory changes affecting other threads or test runners
6. **Simpler tests**: Removed unnecessary `Dir.chdir` calls, making tests clearer and more maintainable
7. **Modern Ruby practices**: Uses keyword arguments for subprocess execution
8. **Better API**: Single source of truth for base directory (Configuration)
9. **Less global state**: Removed global `root_dir` method and environment variable manipulation

## Breaking Changes

None for external users. Internal API changes:
- `ClaudeSwarm.root_dir` method removed (was internal use only)
- `CLAUDE_SWARM_ROOT_DIR` environment variable no longer set by Orchestrator