### PR TITLE
Add support for HTTP MCP server configuration

### DIFF
--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -248,7 +248,7 @@ module ClaudeSwarm
       case mcp["type"]
       when "stdio"
         raise Error, "MCP '#{mcp["name"]}' missing 'command'" unless mcp["command"]
-      when "sse"
+      when "sse", "http"
         raise Error, "MCP '#{mcp["name"]}' missing 'url'" unless mcp["url"]
       else
         raise Error, "Unknown MCP type '#{mcp["type"]}' for '#{mcp["name"]}'"

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -86,9 +86,9 @@ module ClaudeSwarm
         }.tap do |config|
           config["env"] = mcp["env"] if mcp["env"]
         end
-      when "sse"
+      when "sse", "http"
         {
-          "type" => "sse",
+          "type" => mcp["type"],
           "url" => mcp["url"],
         }.tap do |config|
           config["headers"] = mcp["headers"] if mcp["headers"]

--- a/test/helpers/test_helpers.rb
+++ b/test/helpers/test_helpers.rb
@@ -180,7 +180,7 @@ module TestHelpers
       when "stdio"
         assert(server_config.key?("command"))
         assert(server_config.key?("args"))
-      when "sse"
+      when "sse", "http"
 
         assert(server_config.key?("url"))
       end


### PR DESCRIPTION
## Summary

This PR adds support for HTTP MCP (Model Context Protocol) server configuration to claude-swarm, expanding the available server types beyond stdio and SSE.

## Changes

- Added 'http' as a valid MCP server type in the configuration
- Updated validation to accept HTTP type with required 'url' field  
- Modified MCP generator to preserve the actual server type (http/sse) instead of hardcoding 'sse'
- Added comprehensive test coverage for HTTP MCP servers with and without headers
- Updated test helpers to validate HTTP MCP configurations

## Testing

Added two new tests:
-  - validates basic HTTP MCP configuration
-  - validates HTTP MCP with custom headers

All existing tests continue to pass.

## Example Configuration

```yaml
instances:
  myinstance:
    mcps:
      - name: "api_server"
        type: "http"
        url: "http://localhost:3000/mcp"
        headers:
          Authorization: "Bearer token123"
```