### PR TITLE
Update claude-code-sdk-ruby minimum version to 0.1.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     claude_swarm (0.3.11)
-      claude-code-sdk-ruby (~> 0.1)
+      claude-code-sdk-ruby (~> 0.1.6)
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.0)
       fast-mcp-annotations (~> 1.5)

--- a/claude_swarm.gemspec
+++ b/claude_swarm.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("thor", "~> 1.3")
   spec.add_dependency("zeitwerk", "~> 2.6")
 
-  spec.add_dependency("claude-code-sdk-ruby", "~> 0.1")
+  spec.add_dependency("claude-code-sdk-ruby", "~> 0.1.6")
   spec.add_dependency("faraday-net_http_persistent", "~> 2.0")
   spec.add_dependency("faraday-retry", "~> 2.0")
   spec.add_dependency("fast-mcp-annotations", "~> 1.5")


### PR DESCRIPTION
This PR updates the minimum version requirement for claude-code-sdk-ruby from ~> 0.1 to ~> 0.1.6.

This version bump is necessary because the codebase now utilizes the `ClaudeSDK::ClaudeCodeOptions#settings` property that was introduced in claude-code-sdk-ruby [0.1.6](https://github.com/parruda/claude-code-sdk-ruby/blob/0.1.6/CHANGELOG.md#016---2025-07-30). This property allows passing a settings file path to configure Claude Code sessions, which is used to persist and restore instance-specific settings across sessions.

See: `lib/claude_swarm/claude_code_executor.rb:194`