### PR TITLE
Migrate from fast-mcp-annotations to fast-mcp gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       claude-code-sdk-ruby (~> 0.1)
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.0)
-      fast-mcp-annotations (~> 1.5)
+      fast-mcp (~> 1.6)
       ruby-mcp-client (~> 0.7)
       ruby-openai (>= 7.0, < 9.0)
       thor (~> 1.3)
@@ -94,6 +94,13 @@ GEM
       net-http-persistent (>= 4.0.4, < 5)
     faraday-retry (2.3.2)
       faraday (~> 2.0)
+    fast-mcp (1.6.0)
+      addressable (~> 2.8)
+      base64
+      dry-schema (~> 1.14)
+      json (~> 2.0)
+      mime-types (~> 3.4)
+      rack (>= 2.0, < 4.0)
     fast-mcp-annotations (1.5.3)
       addressable (~> 2.8)
       base64

--- a/claude_swarm.gemspec
+++ b/claude_swarm.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("claude-code-sdk-ruby", "~> 0.1")
   spec.add_dependency("faraday-net_http_persistent", "~> 2.0")
   spec.add_dependency("faraday-retry", "~> 2.0")
-  spec.add_dependency("fast-mcp-annotations", "~> 1.5")
+  spec.add_dependency("fast-mcp", "~> 1.6")
   spec.add_dependency("ruby-mcp-client", "~> 0.7")
   spec.add_dependency("ruby-openai", ">= 7.0", "< 9.0")
 


### PR DESCRIPTION
This PR migrates from the `fast-mcp-annotations` gem (~> 1.5) to the `fast-mcp` gem (~> 1.6).

## Changes
- Updated gemspec dependency from `fast-mcp-annotations` to `fast-mcp`
- Updated Gemfile.lock accordingly

The `fast-mcp` [1.6](https://github.com/yjacquin/fast-mcp/blob/main/CHANGELOG.md#160---2025-09-28) includes annotation support (from fast-mcp-annotations) and rack version has been relaxed to include 2 