### PR TITLE
Fix fast_mcp require statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       matrix:
         ruby-version: ['3.2', '3.3', '3.4']
-    
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
-    
+
     - name: Set up Ruby ${{ matrix.ruby-version }}
       uses: ruby/setup-ruby@v1
       with:
@@ -24,6 +24,24 @@ jobs:
         bundler-cache: true
     - name: Install Claude Code
       run: npm install -g @anthropic-ai/claude-code
-    
+
     - name: Run tests and linter
       run: bundle exec rake
+    
+    - name: Test gem loads without bundler
+      run: |
+        gem build *.gemspec
+        gem install ./claude_swarm-*.gem
+        ruby -e "require 'claude_swarm'"
+
+    - name: Test in isolated environment with fresh bundle
+      run: |
+        mkdir -p tmp/gem_test
+        cd tmp/gem_test
+        cat > Gemfile <<EOF
+        source 'https://rubygems.org'
+        gem 'claude_swarm', path: '../..'
+        EOF
+        bundle install
+        bundle exec ruby -e "require 'claude_swarm'; puts 'Gem loaded successfully'"
+        bundle exec claude-swarm version

--- a/lib/claude_swarm.rb
+++ b/lib/claude_swarm.rb
@@ -22,7 +22,7 @@ require "yaml"
 
 # External dependencies
 require "claude_sdk"
-require "fast_mcp_annotations"
+require "fast_mcp"
 require "mcp_client"
 require "thor"
 


### PR DESCRIPTION
This PR fixes the require statement for fast_mcp by replacing `fast_mcp_annotations` with `fast_mcp`.