### PR TITLE
Fix: Add id to MCP notifications/initialized message

### DIFF
--- a/lib/swarm_sdk.rb
+++ b/lib/swarm_sdk.rb
@@ -124,3 +124,19 @@ RubyLLM.configure do |config|
   config.gpustack_api_base ||= ENV["GPUSTACK_API_BASE"]
   config.gpustack_api_key ||= ENV["GPUSTACK_API_KEY"]
 end
+
+# monkey patch ruby_llm/mcp to add `id` when sending "notifications/initialized" message
+# https://github.com/patvice/ruby_llm-mcp/issues/65
+require "ruby_llm/mcp/notifications/initialize"
+
+module RubyLLM
+  module MCP
+    module Notifications
+      class Initialize
+        def call
+          @coordinator.request(notification_body, add_id: true, wait_for_response: false)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
This PR adds a monkey patch to fix the MCP notifications/initialized message by including the 'id' parameter.

## Changes
- Added monkey patch for RubyLLM::MCP::Notifications::Initialize
- The patch ensures the 'id' parameter is included when sending notifications/initialized messages

## Related Issue
Fixes patvice/ruby_llm-mcp#65

## Testing
This fix addresses compatibility issues with MCP message handling.