### PR TITLE
Fix: Add support for prompt_file configuration in agents

### DIFF
--- a/lib/claude_swarm/configuration.rb
+++ b/lib/claude_swarm/configuration.rb
@@ -13,12 +13,13 @@ module ClaudeSwarm
     ENV_VAR_WITH_DEFAULT_PATTERN = /\$\{([^:}]+)(:=([^}]*))?\}/
     O_SERIES_MODEL_PATTERN = /^(o\d+(\s+(Preview|preview))?(-pro|-mini|-deep-research|-mini-deep-research)?|gpt-5(-mini|-nano)?)$/
 
-    attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances
+    attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances, :root_directory
 
     def initialize(config_path, base_dir: nil, options: {})
       @config_path = Pathname.new(config_path).expand_path
       @config_dir = @config_path.dirname
       @base_dir = base_dir || @config_dir
+      @root_directory = @base_dir
       @options = options
       load_and_validate
     end
@@ -207,6 +208,7 @@ module ClaudeSwarm
         disallowed_tools: Array(config["disallowed_tools"]),
         mcps: parse_mcps(config["mcps"] || []),
         prompt: config["prompt"],
+        prompt_file: config["prompt_file"],
         description: config["description"],
         vibe: config["vibe"],
         worktree: parse_worktree_value(config["worktree"]),

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -134,7 +134,16 @@ module ClaudeSwarm
       args.push("--directories", *instance[:directories]) if instance[:directories] && instance[:directories].size > 1
 
       # Add optional arguments
-      args.push("--prompt", instance[:prompt]) if instance[:prompt]
+      # Handle prompt_file by reading the file contents
+      if instance[:prompt_file]
+        prompt_file_path = File.join(@config.root_directory, instance[:prompt_file])
+        if File.exist?(prompt_file_path)
+          prompt_content = File.read(prompt_file_path)
+          args.push("--prompt", prompt_content)
+        end
+      elsif instance[:prompt]
+        args.push("--prompt", instance[:prompt])
+      end
 
       args.push("--description", instance[:description]) if instance[:description]
 


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where `prompt_file` configurations in `claude-swarm.yml` were being ignored, causing agents to run without their specialized system prompts.

## Problem
When users configure agents with `prompt_file` paths like:
```yaml
models_planner:
  description: "ActiveRecord models specialist"
  prompt_file: context/agents/models.md
```

The gem reads the configuration but never loads or passes the prompt file contents to the agent. As a result, agents respond as generic Claude instances instead of specialized experts.

## Solution
This PR modifies two files:

### 1. `lib/claude_swarm/configuration.rb`
- Added `prompt_file` field parsing to read from YAML config
- Added `root_directory` accessor for path resolution

### 2. `lib/claude_swarm/mcp_generator.rb`
- Check for `prompt_file` configuration first
- Read file contents from root-relative path  
- Pass contents via `--prompt` flag to `mcp-serve`
- Fall back to inline `prompt` if no `prompt_file`

## Testing
Verified that agents now correctly:
1. Load their prompt files from the specified paths
2. Respond with specialized knowledge from their prompt files
3. Behave as domain experts rather than generic Claude instances

## Compatibility
- Backward compatible - existing `prompt` (inline) configurations still work
- No breaking changes to the API or configuration format

🤖 Generated with [Claude Code](https://claude.com/claude-code)