### PR TITLE
Fix MCP parameter type handling

### DIFF
--- a/lib/swarm_sdk.rb
+++ b/lib/swarm_sdk.rb
@@ -134,12 +134,24 @@ RubyLLM.configure do |config|
   config.gpustack_api_key ||= ENV["GPUSTACK_API_KEY"]
 end
 
-# monkey patch ruby_llm/mcp to add `id` when sending "notifications/initialized" message
-# https://github.com/patvice/ruby_llm-mcp/issues/65
+# monkey patches
+# ruby_llm/mcp
+# - add `id` when sending "notifications/initialized" message: https://github.com/patvice/ruby_llm-mcp/issues/65
+# - remove `to_sym` on MCP parameter type: https://github.com/patvice/ruby_llm-mcp/issues/62#issuecomment-3421488406
 require "ruby_llm/mcp/notifications/initialize"
+require "ruby_llm/mcp/parameter"
 
 module RubyLLM
   module MCP
+    class Parameter < RubyLLM::Parameter
+      def initialize(name, type: "string", desc: nil, required: true, default: nil, union_type: nil)
+        super(name, type: type, desc: desc, required: required)
+        @properties = {}
+        @union_type = union_type
+        @default = default
+      end
+    end
+
     module Notifications
       class Initialize
         def call


### PR DESCRIPTION
This PR adds a monkey patch to fix parameter type handling in ruby_llm-mcp.

## Changes
- Add monkey patch to override RubyLLM::MCP::Parameter initialization to remove `to_sym` conversion on parameter type
- Update comments to document both MCP monkey patches (initialized notification and parameter type)

## Context
This fixes an issue where parameter types were being converted to symbols, which was causing problems with MCP parameter handling.

Related: https://github.com/patvice/ruby_llm-mcp/issues/62