### PR TITLE
Update CHANGELOG and version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
       tty-spinner
       tty-tree
       zeitwerk
-    swarm_sdk (2.0.5)
+    swarm_sdk (2.0.6)
       async (~> 2.0)
       ruby_llm (~> 1.8)
       ruby_llm-mcp

--- a/docs/v2/CHANGELOG.swarm_sdk.md
+++ b/docs/v2/CHANGELOG.swarm_sdk.md
@@ -5,6 +5,12 @@ All notable changes to SwarmSDK will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.6]
+
+### Fixed
+- **MCP parameter type handling**: Fixed issue with parameter type conversion in ruby_llm-mcp
+  - Added monkey patch to remove `to_sym` conversion on MCP parameter types
+
 ## [2.0.5]
 
 ### Added

--- a/lib/swarm_sdk/version.rb
+++ b/lib/swarm_sdk/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SwarmSDK
-  VERSION = "2.0.5"
+  VERSION = "2.0.6"
 end


### PR DESCRIPTION
# SwarmSDK v2.0.6 Release

## Summary
This PR updates SwarmSDK from version 2.0.5 to 2.0.6, addressing a critical bug fix related to MCP parameter type handling.

## Changes

### Version Bump
- **SwarmSDK**: `2.0.5` → `2.0.6`

### Bug Fixes
- **Fixed MCP parameter type handling** in ruby_llm-mcp integration
  - Resolved issue with parameter type conversion that was causing incorrect type handling
  - Added monkey patch to prevent unwanted `to_sym` conversion on MCP parameter types
  - This ensures proper type preservation when passing parameters to MCP tools

## Files Changed
- `lib/swarm_sdk/version.rb` - Updated version constant
- `docs/v2/CHANGELOG.swarm_sdk.md` - Added changelog entry for v2.0.6
- `Gemfile.lock` - Updated lock file with new version

## Impact
This patch release ensures that MCP tools receive parameters with correct type information, preventing potential runtime errors or unexpected behavior when tools validate parameter types. This is particularly important for tools that rely on strict type checking.

## Testing
- [ ] Version number correctly updated in all locations
- [ ] CHANGELOG properly documents the fix
- [ ] MCP parameter types are preserved correctly
- [ ] No breaking changes introduced

## Checklist
- [x] Version bumped appropriately (patch version for bug fix)
- [x] CHANGELOG updated with clear description
- [x] Gemfile.lock updated
- [ ] All tests passing
- [ ] Ready to merge

## Release Type
🐛 **Bug Fix** - Patch Release (2.0.6)

---

**Related Issues**: N/A
**Breaking Changes**: None
**Dependencies**: ruby_llm-mcp

