### PR TITLE
Fix Delegate tool description API serialization error

### DIFF
--- a/lib/swarm_sdk/tools/delegate.rb
+++ b/lib/swarm_sdk/tools/delegate.rb
@@ -43,8 +43,8 @@ module SwarmSDK
         @delegate_target = delegate_name.to_s
       end
 
-      # Build description dynamically based on delegate
-      description do
+      # Override description to return dynamic string based on delegate
+      def description
         "Delegate tasks to #{@delegate_name}. #{@delegate_description}"
       end
 


### PR DESCRIPTION
## Problem

The Delegate tool causes API serialization errors when used in SwarmSDK workflows:

```
tools.10.custom.description: Input should be a valid string
```

This breaks all workflows that use agent delegation (coordinator → specialist pattern).

## Root Cause

**Problematic commit**: `66d87bb` (Oct 16, 2025) - "Implement SwarmSDK and SwarmCLI"  
**Affected versions**: SwarmSDK v2.0.0 through v2.1.1 (current)  
**ruby_llm dependency**: ~> 1.8 (all versions affected)

The Delegate tool was using incorrect syntax for `RubyLLM::Tool.description`:

```ruby
# lib/swarm_sdk/tools/delegate.rb:47-49 (WRONG)
description do
  "Delegate tasks to #{@delegate_name}. #{@delegate_description}"
end
```

### Why This Fails

`RubyLLM::Tool.description` is a **class method** that expects a String argument, not a block:

```ruby
# From ruby_llm gem (lib/ruby_llm/tool.rb:32-36)
def description(text = nil)
  return @description unless text
  @description = text
end
```

When called with `do...end` block syntax, Ruby passes a **Proc object** to the method as a block parameter. Since `description()` doesn't accept blocks (no `&block` parameter), and the block isn't being called, the Proc never gets evaluated to a String. Instead, `@description` is set to the Proc object itself.

When SwarmSDK serializes tools for the LLM API, it sends the Proc object instead of a String, causing validation errors from the API provider.

## Solution

Override the **instance method** `description` to return a dynamic string:

```ruby
# lib/swarm_sdk/tools/delegate.rb:46-49 (FIXED)
def description
  "Delegate tasks to #{@delegate_name}. #{@delegate_description}"
end
```

This matches the pattern used for overriding `name` (line 57-59) and ensures proper String serialization.

## Testing

### Before Fix
```ruby
Workflow.new("math").run
# Error: tools.10.custom.description: Input should be a valid string
# Retry attempts: 10/10
# Duration: ~90 seconds of failures
# Result: Failure
```

### After Fix
```ruby
Workflow.new("math").run
# ✅ Success: "The answer is: 2"
# Duration: ~7 seconds
# Cost: $0.020
# Agents: coordinator → math_solver delegation works correctly
```

## How Other Tools Do It Correctly

All other SwarmSDK tools use the correct pattern with heredoc or string literal:

```ruby
# lib/swarm_sdk/tools/think.rb:19
description <<~DESC
  Tool description here
DESC

# lib/swarm_sdk/tools/read.rb:31
description <<~DESC
  Reads a file...
DESC
```

The heredoc creates a String literal that gets passed as an argument to `description()`.

## Detailed History

### SwarmSDK Timeline

- **2025-10-16** (commit `66d87bb`): Initial implementation with bug
  - SwarmSDK v2.0.0 released
  - Delegate tool created with `description do` block
  - Bug present from day one

- **2025-10-17 - 2025-10-28**: Bug persists through all releases
  - v2.0.1 through v2.1.1: Bug remains unchanged
  - No modifications to `lib/swarm_sdk/tools/delegate.rb` except this fix

### ruby_llm Behavior

The ruby_llm gem's `Tool.description` API has been consistent:
- Expects String argument: `description "text"`
- Never supported block syntax: `description do...end`
- All versions ~> 1.8 exhibit same behavior

This is a bug in SwarmSDK's usage of the ruby_llm API, not a ruby_llm breaking change.

## Impact

- ✅ Fixes delegation in all SwarmSDK workflows using Ruby DSL
- ✅ No breaking changes - maintains same API surface
- ✅ Minimal diff: 2 lines changed
- ✅ Compatible with all ruby_llm ~> 1.8 versions
- ✅ No test changes needed (existing tests pass)

## Reproduction Case

Create a workflow with coordinator → specialist delegation:

```ruby
require "swarm_sdk"

swarm = SwarmSDK.build do
  name "Math Workflow"
  lead :coordinator
  use_scratchpad true
  
  agent :coordinator, coordinator_content do
    provider "anthropic"
    model "sonnet"
  end
  
  agent :math_solver, math_solver_content do
    provider "anthropic"
    model "sonnet"
  end
end

result = swarm.execute("Calculate 1+1")
# Before fix: API error on tools.10.custom.description
# After fix: ✅ Works correctly
```

The bug affects tool #10 (or whichever index the DelegateTaskTo* tool appears at) because it's the only tool using dynamic description generation with instance variables.

## Related Issues

- No existing GitHub issues found for this bug
- Discovered while integrating SwarmSDK v2 into https://github.com/HuxleyIQ/huxley
- Workaround was to monkey-patch in `config/initializers/swarm_sdk.rb`
- This PR provides the proper upstream fix