### PR TITLE
Remove RUBYOPT and RUBYLIB from MCP server environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [Unreleased]
+
+### Fixed
+- **Fixed Ruby environment variable conflicts in MCP servers**: Removed RUBYOPT and RUBYLIB from MCP server configurations to prevent Bundler interference
+  - MCP servers no longer inherit RUBYOPT and RUBYLIB environment variables from the parent process
+  - Also removed BUNDLE_* environment variables to ensure MCP servers use the system-installed gem
+  - Prevents conflicts when Claude Swarm is run from within a bundled Ruby project
+  - Ensures MCP servers run with clean Ruby environments without unexpected gem loading behavior
+
 ## [1.0.3]
 
 ### Fixed

--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -183,21 +183,17 @@ module ClaudeSwarm
         args.push("--claude-session-id", claude_session_id) if claude_session_id
       end
 
-      # Capture environment variables needed for Ruby and Bundler to work properly
-      # This includes both BUNDLE_* variables and Ruby-specific variables
+      # Capture environment variables needed for running claude-swarm
+      # We intentionally exclude Bundler variables to ensure we use the system-installed gem
       required_env = {}
 
-      # Bundle-specific variables
-      ENV.each do |k, v|
-        required_env[k] = v if k.start_with?("BUNDLE_")
-      end
-
-      # Claude Swarm-specific variables
+      # Claude Swarm-specific variables (always needed)
       ENV.each do |k, v|
         required_env[k] = v if k.start_with?("CLAUDE_SWARM_")
       end
 
       # Ruby-specific variables that MCP servers need
+      # Exclude RUBYOPT and RUBYLIB to avoid Bundler interference
       [
         "RUBY_ROOT",
         "RUBY_ENGINE",
@@ -205,8 +201,6 @@ module ClaudeSwarm
         "GEM_ROOT",
         "GEM_HOME",
         "GEM_PATH",
-        "RUBYOPT",
-        "RUBYLIB",
         "PATH",
       ].each do |key|
         required_env[key] = ENV[key] if ENV[key]


### PR DESCRIPTION
## Summary

This PR cleans up the environment variables passed to MCP servers by removing Ruby and Bundler-specific variables that can cause interference.

## Changes

- Removed `RUBYOPT` and `RUBYLIB` from the list of environment variables passed to MCP servers
- Removed automatic capture of `BUNDLE_*` environment variables
- Updated comments to clarify the intentional exclusion of Bundler variables

## Motivation

When starting MCP servers, we want to ensure they use the system-installed gem rather than being influenced by the development environment's Bundler configuration. Variables like `RUBYOPT` and `RUBYLIB` can cause the MCP server to inadvertently use development dependencies or configurations, leading to unexpected behavior.

## Testing

- Verify MCP servers start correctly without Bundler interference
- Confirm `CLAUDE_SWARM_*` variables are still properly passed through
- Ensure PATH and other essential Ruby variables remain available

## Impact

This change should make MCP servers more reliable and predictable by isolating them from the parent process's Bundler environment.