### PR TITLE
Fix: Preserve environment variables in MCP configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.7]
+
+### Fixed
+- **Preserve environment variables in MCP configurations**: Fixed environment variable interpolation to skip MCP server configurations
+  - Environment variables in MCP configs are now preserved as-is (e.g., `${TOKEN}` stays as `${TOKEN}`)
+  - Allows MCP servers to perform their own environment variable interpolation if needed
+  - Previously, variables were expanded too early, preventing MCP servers from handling dynamic values
+
 ## [1.0.6]
 
 ### Fixed

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1573,8 +1573,9 @@ class ConfigurationTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     mcp = config.main_instance_config[:mcps].first
 
-    assert_equal("github-expert", mcp["name"])
-    assert_equal("mcp-server-github", mcp["command"])
+    # MCP configurations should preserve environment variables
+    assert_equal("${TEST_ENV_MCP_NAME}", mcp["name"])
+    assert_equal("${TEST_ENV_MCP_COMMAND}", mcp["command"])
   end
 
   def test_env_var_interpolation_multiple_in_same_string
@@ -1653,8 +1654,9 @@ class ConfigurationTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     mcp = config.main_instance_config[:mcps].first
 
-    assert_equal("https://api.example.com", mcp["url"])
-    assert_equal(["--verbose", "--port=8080"], mcp["args"])
+    # MCP configurations should preserve environment variables
+    assert_equal("${TEST_ENV_URL}", mcp["url"])
+    assert_equal(["${TEST_ENV_ARG}", "--port=8080"], mcp["args"])
   end
 
   def test_env_var_interpolation_in_before_commands
@@ -2073,8 +2075,9 @@ class ConfigurationTest < Minitest::Test
     config = ClaudeSwarm::Configuration.new(@config_path)
     mcps = config.main_instance_config[:mcps]
 
-    assert_equal("default-mcp-server", mcps[0]["command"])
-    assert_equal("http://localhost:8080", mcps[1]["url"])
+    # MCP configurations should preserve environment variables even with defaults
+    assert_equal("${TEST_ENV_MCP_CMD:=default-mcp-server}", mcps[0]["command"])
+    assert_equal("${TEST_ENV_MCP_URL:=http://localhost:8080}", mcps[1]["url"])
   end
 
   def test_env_var_default_in_worktree_string


### PR DESCRIPTION
## Summary

This PR fixes an issue where environment variables were being prematurely interpolated in MCP (Model Context Protocol) server configurations, preventing MCP servers from performing their own environment variable resolution.

Fix #160

## Problem

Previously, the configuration loader would interpolate all environment variables during the configuration loading phase, including those within MCP server configurations. This caused issues when:
- MCP servers expected to receive environment variables as-is (e.g., `${VAR_NAME}`)
- MCP servers needed to perform their own variable interpolation
- Environment variables needed to be evaluated in the MCP server's context rather than the loader's context

## Solution

- **Added path tracking** to the `interpolate_env_vars!` method to track the current location in the configuration tree
- **Implemented `in_mcp_config?` helper** to detect when processing values inside MCP configurations
  - Checks for the pattern: `instances > <name> > mcps > <index>`
- **Skip interpolation** for any values inside MCP configurations
- **Updated tests** to verify that environment variables are preserved in MCP configurations

## Changes

### `lib/claude_swarm/configuration.rb`
- Modified `interpolate_env_vars!` to accept and pass along a `path` parameter
- Added `in_mcp_config?` method to identify MCP configuration contexts
- Conditionally skip interpolation when inside MCP configs

### `test/configuration_test.rb`
- Updated test expectations to verify environment variables are preserved
- Tests now assert that values like `${TEST_ENV_MCP_NAME}` remain unchanged in MCP configs

## Testing

All existing tests pass with the updated behavior. The changes ensure:
- ✅ Environment variables in MCP configurations are preserved as-is
- ✅ Environment variables in other parts of the configuration are still interpolated
- ✅ Both simple (`${VAR}`) and default (`${VAR:=default}`) syntax are preserved in MCP configs

## Impact

- **MCP servers** can now receive and handle environment variables as intended
- **Backward compatible** for configurations that don't use environment variables
- **No breaking changes** to existing functionality outside of MCP configurations
