### PR TITLE
Fix Zeitwerk inflector for MCP module

### DIFF
--- a/lib/swarm_sdk.rb
+++ b/lib/swarm_sdk.rb
@@ -25,6 +25,7 @@ loader.push_dir("#{__dir__}/swarm_sdk", namespace: SwarmSDK)
 loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
 loader.inflector.inflect(
   "cli" => "CLI",
+  "mcp" => "MCP",
   "openai_with_responses" => "OpenAIWithResponses",
 )
 loader.setup


### PR DESCRIPTION
## Summary

Adds missing Zeitwerk inflector rule for MCP acronym.

My apologies for the regression in f393a42 (https://github.com/parruda/swarm/pull/159) which should have included this inflector rule when introducing the MCP module. (I have no idea how this one got by me!)

## Problem

```
Zeitwerk::NameError: expected file lib/swarm_sdk/mcp.rb to define constant SwarmSDK::Mcp, but didn't
```

Occurs during eager loading (production boot, CI with `config.eager_load = true`).

## Root Cause

**Commit**: f393a42 (Oct 30, 2024) - Introduced `module MCP` in `lib/swarm_sdk/mcp.rb`
**Issue**: Zeitwerk expects `module Mcp` based on filename. Acronyms need explicit inflector rules.

## Solution

```ruby
loader.inflector.inflect(
  "cli" => "CLI",
  "mcp" => "MCP",  # Added
  "openai_with_responses" => "OpenAIWithResponses",
)
```

Follows existing `"cli" => "CLI"` pattern.

## Testing

**Before**: `bin/rails zeitwerk:check` ❌ NameError
**After**: `bin/rails zeitwerk:check` ✅ All good

Verified in production Rails app via this fork.

## Related Work

- **Follow-up PR coming**: Will add `bin/rails zeitwerk:check` to CI workflow to prevent future regressions
- **Related PR for ruby_llm coming**: Railtie conditional loading fix, will be required for the `zeitwerk:check` in swarm

I'm sorry for the confusion here, thanks again for your wonderful gem! I've been having a great time hooking things up in my new app, and it's going great (except for these loading issues lol!)