### PR TITLE
Add Zeitwerk eager loading check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,10 @@ jobs:
 
     - name: Run SwarmSDK linter
       run: bundle exec rake swarm_sdk:rubocop
-    
+
+    - name: Check Zeitwerk eager loading
+      run: bundle exec ruby -e "require 'swarm_sdk'; Zeitwerk::Loader.eager_load_all"
+
     - name: Test SwarmSDK gem loads without bundler
       run: |
         gem build swarm_sdk.gemspec


### PR DESCRIPTION
## Summary

Adds Zeitwerk eager loading validation to CI to catch autoloading issues before release.

## Problem

Lack of CI check for catching eager loading issues. Recent example: MCP inflector bug (PR #163) would have been caught by this check.

## Solution

Add `Zeitwerk::Loader.eager_load_all` check after linter step:

```ruby
bundle exec ruby -e "require 'swarm_sdk'; Zeitwerk::Loader.eager_load_all"
```

**Placement**: After linter, before gem loading tests
- Structural validation happens together  
- Fast fail before expensive gem build steps

## Blocked

**This PR is DRAFT** and blocked on:

1. **swarm_sdk MCP PR**: https://github.com/parruda/swarm/pull/163
   - Fixes MCP inflector (the issue that motivated this check)
   - Current check would fail without this fix

2. **ruby_llm PR**: https://github.com/crmne/ruby_llm/pull/486
   - Fixes railtie eager loading crash
   - swarm_sdk depends on ruby_llm
   - Current check would fail due to railtie issue

We can mark as ready after both PRs are merged and released.

## Testing

**Current (without fixes)**: ❌ Fails with railtie and MCP errors  
**After both PRs**: ✅ Passes

## Benefits

- Catches inflector issues (MCP, CLI, etc.)
- Catches constant definition issues
- Fast fail (~2s check)
- Prevents production crashes

Thanks again, and apologies for the noise!