### PR TITLE
Release version 1.0.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_swarm (1.0.6)
+    claude_swarm (1.0.7)
       claude-code-sdk-ruby (~> 0.1.6)
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end


### PR DESCRIPTION
## What's Changed

### Fixed
- **Preserve environment variables in MCP configurations**: Fixed environment variable interpolation to skip MCP server configurations
  - Environment variables in MCP configs are now preserved as-is (e.g., `${TOKEN}` stays as `${TOKEN}`)
  - Allows MCP servers to perform their own environment variable interpolation if needed
  - Previously, variables were expanded too early, preventing MCP servers from handling dynamic values

## Version Update
- Bumped version from 1.0.6 to 1.0.7