### PR TITLE
Release version 1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.9]
+
+### Added
+- **Zero Data Retention (ZDR) support for OpenAI Responses API**: Added ZDR mode to disable conversation continuity for privacy-focused use cases
+  - New `zdr` configuration parameter (boolean) that can be set in YAML configuration files
+  - When enabled, sets `previous_response_id` to nil, ensuring each API call is independent
+  - Supported in Configuration, CLI (`--zdr` flag), and MCP generator
+
 ## [1.0.8]
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    claude_swarm (1.0.8)
+    claude_swarm (1.0.9)
       claude-code-sdk-ruby (~> 0.1.6)
       faraday-net_http_persistent (~> 2.0)
       faraday-retry (~> 2.0)

--- a/lib/claude_swarm/version.rb
+++ b/lib/claude_swarm/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ClaudeSwarm
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end


### PR DESCRIPTION
# Release Claude Swarm 1.0.9

## Summary
This release adds Zero Data Retention (ZDR) support for the OpenAI Responses API, enabling privacy-focused use cases where conversation continuity needs to be disabled.

## What's Changed

### Added
- **Zero Data Retention (ZDR) support for OpenAI Responses API**: Added ZDR mode to disable conversation continuity for privacy-focused use cases
  - New `zdr` configuration parameter (boolean) that can be set in YAML configuration files
  - When enabled, sets `previous_response_id` to nil, ensuring each API call is independent
  - Supported in Configuration, CLI (`--zdr` flag), and MCP generator

## Impact
- Users can now enable ZDR mode for OpenAI instances to ensure no conversation history is retained between requests
- This is particularly useful for compliance requirements and privacy-focused applications
- The feature is opt-in and does not affect existing configurations

## Configuration Example
```yaml
instances:
  - name: assistant
    provider: openai
    api_version: responses
    zdr: true  # Enable Zero Data Retention
```

Or via CLI:
```bash
claude-swarm start config.yml --zdr
```

## Version Bump
- Version bumped from 1.0.8 to 1.0.9
- CHANGELOG.md updated with release notes

