### PR TITLE
Fix undefined method 'root_directory' error in McpGenerator

### DIFF
--- a/lib/claude_swarm/mcp_generator.rb
+++ b/lib/claude_swarm/mcp_generator.rb
@@ -123,7 +123,7 @@ module ClaudeSwarm
       # Add optional arguments
       # Handle prompt_file by reading the file contents
       if instance[:prompt_file]
-        prompt_file_path = File.join(@config.root_directory, instance[:prompt_file])
+        prompt_file_path = File.join(@config.base_dir, instance[:prompt_file])
         if File.exist?(prompt_file_path)
           prompt_content = File.read(prompt_file_path)
           args.push("--prompt", prompt_content)


### PR DESCRIPTION
## Problem

The `McpGenerator` class was calling `@config.root_directory` on line 126, but the `Configuration` class only exposes `base_dir`, not `root_directory`. This caused a `NoMethodError` when instances used the `prompt_file` configuration option.

### Error Message
```
undefined method 'root_directory' for an instance of ClaudeSwarm::Configuration
```

## Solution

Changed line 126 in `lib/claude_swarm/mcp_generator.rb` from:
```ruby
prompt_file_path = File.join(@config.root_directory, instance[:prompt_file])
```

to:
```ruby
prompt_file_path = File.join(@config.base_dir, instance[:prompt_file])
```

## Testing

Verified the fix resolves the error when running `claude-swarm` with a configuration that includes `prompt_file` settings for instances.

## Related

The `Configuration` class (in `lib/claude_swarm/configuration.rb`) defines `base_dir` on line 14 as:
```ruby
attr_reader :config, :config_path, :swarm, :swarm_name, :main_instance, :instances, :base_dir
```

This appears to be the correct attribute to use for resolving relative paths to prompt files.